### PR TITLE
Fixed users filtering

### DIFF
--- a/includes/directory.php
+++ b/includes/directory.php
@@ -37,9 +37,15 @@ function pmpro_bp_bp_pre_user_query_construct( $query_array ) {
 		if( is_array( $query_array->query_vars['include'] ) ) {
 			// Compute the intersect of members and include value.
 			$query_array->query_vars['include'] = array_intersect( $query_array->query_vars['include'], $pmpro_bp_members_in_directory );
+			if (count ($query_array->query_vars['include']) == 0)
+				$query_array->query_vars['include'] = array(0);
 		} else {
-			// Only include members in the directory.
-			$query_array->query_vars['include'] = $pmpro_bp_members_in_directory;
+			if ( is_string($query_array->query_vars['include']) && $query_array->query_vars['include'] == "0" )
+				$query_array->query_vars['include'] = array(0);
+			else {
+				// Only include members in the directory.
+				$query_array->query_vars['include'] = $pmpro_bp_members_in_directory;
+			}
 		}
 	} else {
 		// No members, block the directory.


### PR DESCRIPTION
If no filter is picked now returns empty directory instead of all users.

This behavior was already reported here: https://wordpress.org/support/topic/suggesting-a-patch/ so I just implemented it and fixed for latest version as reported in last answer (https://wordpress.org/support/topic/suggesting-a-patch/#post-11589486), also improving BP Profile Search plugin compatibilty.