### PR TITLE
Add to groups fix

### DIFF
--- a/includes/groups.php
+++ b/includes/groups.php
@@ -10,11 +10,13 @@
 function pmpro_bp_set_member_groups( $level_id, $user_id, $cancel_level ) {
 
 	// Make sure Groups are activated.
-	if(!function_exists('groups_accept_invite')) return;
-	
+	if ( ! function_exists( 'groups_accept_invite' ) ) {
+		return;
+	}
+
 	$pmpro_bp_options = pmpro_bp_get_user_options( $user_id );
 
-	if( !empty( $cancel_level ) ) {
+	if ( ! empty( $cancel_level ) ) {
 		$pmpro_bp_old_level_options = pmpro_bp_get_level_options( $cancel_level );
 	} else {
 		$pmpro_bp_old_level_options = pmpro_bp_get_user_old_level_options( $user_id );
@@ -23,14 +25,14 @@ function pmpro_bp_set_member_groups( $level_id, $user_id, $cancel_level ) {
 	$old_groups = $pmpro_bp_old_level_options['pmpro_bp_group_automatic_add'];
 	$new_groups = $pmpro_bp_options['pmpro_bp_group_automatic_add'];
 
-	if( !empty( $old_groups ) ) {
-		foreach($old_groups as $group_id) {
+	if ( ! empty( $old_groups ) ) {
+		foreach ( $old_groups as $group_id ) {
 			groups_leave_group( $group_id, $user_id );
 		}
 	}
 
-	if( !empty( $new_groups ) ) {
-		foreach($new_groups as $group_id) {
+	if ( ! empty( $new_groups ) ) {
+		foreach ( $new_groups as $group_id ) {
 			groups_accept_invite( $user_id, $group_id );
 		}
 	}

--- a/includes/groups.php
+++ b/includes/groups.php
@@ -45,6 +45,8 @@ function pmpro_bp_set_member_groups( $level_id, $user_id, $cancel_level ) {
 	if ( ! empty( $old_groups_invite ) ) {
 		foreach ( $old_groups_invite as $group_id ) {
 			groups_uninvite_user( $user_id, $group_id );
+			// remove user from group as well
+			groups_leave_group( $group_id, $user_id );
 		}
 	}
 

--- a/includes/groups.php
+++ b/includes/groups.php
@@ -10,7 +10,7 @@
 function pmpro_bp_set_member_groups( $level_id, $user_id, $cancel_level ) {
 
 	// Make sure Groups are activated.
-	if ( ! function_exists( 'groups_accept_invite' ) ) {
+	if ( ! function_exists( 'groups_create_group' ) ) {
 		return;
 	}
 
@@ -22,6 +22,7 @@ function pmpro_bp_set_member_groups( $level_id, $user_id, $cancel_level ) {
 		$pmpro_bp_old_level_options = pmpro_bp_get_user_old_level_options( $user_id );
 	}
 
+	// Add to groups
 	$old_groups = $pmpro_bp_old_level_options['pmpro_bp_group_automatic_add'];
 	$new_groups = $pmpro_bp_options['pmpro_bp_group_automatic_add'];
 
@@ -33,7 +34,7 @@ function pmpro_bp_set_member_groups( $level_id, $user_id, $cancel_level ) {
 
 	if ( ! empty( $new_groups ) ) {
 		foreach ( $new_groups as $group_id ) {
-			groups_accept_invite( $user_id, $group_id );
+			groups_join_group( $group_id, $user_id );
 		}
 	}
 }

--- a/includes/groups.php
+++ b/includes/groups.php
@@ -37,5 +37,31 @@ function pmpro_bp_set_member_groups( $level_id, $user_id, $cancel_level ) {
 			groups_join_group( $group_id, $user_id );
 		}
 	}
+
+	// Invite to groups
+	$old_groups_invite = $pmpro_bp_old_level_options['pmpro_bp_group_can_request_invite'];
+	$new_groups_invite = $pmpro_bp_options['pmpro_bp_group_can_request_invite'];
+
+	if ( ! empty( $old_groups_invite ) ) {
+		foreach ( $old_groups_invite as $group_id ) {
+			groups_uninvite_user( $user_id, $group_id );
+		}
+	}
+
+	if ( ! empty( $new_groups_invite ) ) {
+		foreach ( $new_groups_invite as $group_id ) {
+			$group = groups_get_group( array( 'group_id' => $group_id ) );
+			groups_invite_user(
+				array(
+					'user_id'       => $user_id,
+					'group_id'      => $group_id,
+					'inviter_id'    => $group->creator_id,
+					'date_modified' => bp_core_current_time(),
+					'send_invite'   => 1,
+				)
+			);
+		}
+	}
+
 }
 add_action( 'pmpro_after_change_membership_level', 'pmpro_bp_set_member_groups', 10, 3 );


### PR DESCRIPTION
Issue: https://github.com/strangerstudios/pmpro-buddypress/issues/64

- Refactor original code to WPCS.
- Join user to a group with `groups_join_group` instead of `groups_accept_invite` function
- Add missing functionality to invite and uninvite users to a group.