### PR TITLE
Prevent redirect_loop

### DIFF
--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -231,7 +231,7 @@ function pmpro_bp_buddypress_or_pmpro_registration() {
 	
 	if( !empty( $pmpro_bp_register ) && $pmpro_bp_register == 'buddypress' && isset( $post->ID ) && $post->ID != 0 && $post->ID == $pmpro_pages['levels'] && !is_user_logged_in() ) {
 		// Some cases the BuddyPress/BuddyBoss register page is set to same permalink - causes an error.
-		if ( get_permalink( $bp_pages['register'] ) === get_permalink( $pmpro_pages['levels'] ) ) {
+		if ( empty( $bp_pages['register'] ) || get_permalink( $bp_pages['register'] ) === get_permalink( $pmpro_pages['levels'] ) ) {
 			return;
 		}
 		

--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -230,6 +230,11 @@ function pmpro_bp_buddypress_or_pmpro_registration() {
 	$pmpro_bp_register = get_option( 'pmpro_bp_registration_page' );
 	
 	if( !empty( $pmpro_bp_register ) && $pmpro_bp_register == 'buddypress' && isset( $post->ID ) && $post->ID != 0 && $post->ID == $pmpro_pages['levels'] && !is_user_logged_in() ) {
+		// Some cases the BuddyPress/BuddyBoss register page is set to same permalink - causes an error.
+		if ( get_permalink( $bp_pages['register'] ) === get_permalink( $pmpro_pages['levels'] ) ) {
+			return;
+		}
+		
 		//Use BuddyPress Register page
 		wp_redirect( get_permalink( $bp_pages['register'] ) );
 		exit;


### PR DESCRIPTION
* BUG FIX: Fixed an issue where the BuddyPress/BuddyBoss registration page was set to Paid Memberships Pro levels page. Check to ensure these URL's aren't the same and prevent a redirect loop issue.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### How to test the changes in this Pull Request:

I'm not entirely sure on clear steps to replicate, but it may be BuddyBoss related where not setting the registration in BuddyBoss defaults to PMPro's level's page.

1. Set registration page option to "Use BuddyPress".
2. Don't have anything configured in BuddyBoss (latest version) - Theme and Platform.
3. Try to load the Level select page on the frontend.
4. See error. Apply PR, error should disappear.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
