### PR TITLE
Fix BuddyPress profile field sync

### DIFF
--- a/includes/profiles.php
+++ b/includes/profiles.php
@@ -14,7 +14,7 @@ function pmpro_bp_update_user_meta( $meta_id, $user_id, $meta_key, $meta_value )
 		return;
 	}
 	
-	if ( ! defined( 'xprofile_get_field_id_from_name' ) ) {
+	if ( ! function_exists( 'xprofile_get_field_id_from_name' ) ) {
 		return;
 	}
 


### PR DESCRIPTION
The check to ensure that BuddyPress is active is using `defined` to check if a function exists, this leads to the execution prematurely exiting before syncing the fields in the `pmpro_bp_update_user_meta` function. 

Fixes: https://github.com/strangerstudios/pmpro-buddypress/issues/89

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Change to using `function_exists` instead of `defined` to check if a function exists.

### How to test the changes in this Pull Request:

1. Create fields for Register Helper with a `buddypress` parameter to sync with a BuddyPress xProfile field
2. Check out for a membership level
3. Navigate to the user's BuddyPress Profile page to confirm these fields were synced

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

