### PR TITLE
Fix a couple of redirect issues for registration.

### DIFF
--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -240,7 +240,7 @@ function pmpro_bp_buddypress_or_pmpro_registration() {
 	
 	$pmpro_bp_register = get_option( 'pmpro_bp_registration_page' );
 	
-	if( !empty( $pmpro_bp_register ) && $pmpro_bp_register == 'buddypress' && isset( $post->ID ) && $post->ID != 0 && $post->ID == $pmpro_pages['levels'] && !is_user_logged_in() ) {
+	if( ! empty( $bp_pages['register'] ) && ! empty( $pmpro_bp_register ) && $pmpro_bp_register == 'buddypress' && isset( $post->ID ) && $post->ID != 0 && $post->ID == $pmpro_pages['levels'] && ! is_user_logged_in() ) {
 		// Some cases the BuddyPress/BuddyBoss register page is set to same permalink - causes an error.
 		if ( empty( $bp_pages['register'] ) || get_permalink( $bp_pages['register'] ) === get_permalink( $pmpro_pages['levels'] ) ) {
 			return;

--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -172,7 +172,8 @@ add_filter( 'bp_get_add_friend_button', 'pmpro_bp_bp_get_add_friend_button' );
  * Redirect away from any BuddyPress page if set to.
  */
 function pmpro_bp_lockdown_all_bp() {
-		
+	global $pmpro_pages;
+	
 	if ( !function_exists( 'pmpro_getMembershipLevelForUser' ) ) {
 		return;
 	}
@@ -184,6 +185,11 @@ function pmpro_bp_lockdown_all_bp() {
 	// Don't redirect away from the Register or Activate pages if using BuddyPress registration.
 	$register_page = get_option( 'pmpro_bp_registration_page' );
 	if ( 'buddypress' == $register_page && in_array( bp_current_component(), array( 'register', 'activate' ) ) ) {
+		return;
+	}
+	
+	// Fixes an issue with BuddyBoss configuration if registration page is set to PMPro + BuddyBoss registration page is set to Levels page.
+	if ( 'pmpro' == $register_page && is_page( $pmpro_pages['levels'] ) ) {
 		return;
 	}
 	
@@ -234,12 +240,12 @@ function pmpro_bp_buddypress_or_pmpro_registration() {
 		if ( empty( $bp_pages['register'] ) || get_permalink( $bp_pages['register'] ) === get_permalink( $pmpro_pages['levels'] ) ) {
 			return;
 		}
-		
+
 		//Use BuddyPress Register page
 		wp_redirect( get_permalink( $bp_pages['register'] ) );
 		exit;
 	}
-	elseif( !empty( $pmpro_bp_register ) && $pmpro_bp_register == 'pmpro' && bp_is_register_page() && $post->ID != $pmpro_pages['levels'] )
+	elseif( !empty( $pmpro_bp_register ) && $pmpro_bp_register == 'pmpro' && bp_is_register_page() && ( ! is_page( $pmpro_pages['levels'] ) || $post->ID != $pmpro_pages['levels'] ) )
 	{
 		//use PMPro Levels page
 		$url = pmpro_url("levels");

--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -189,7 +189,7 @@ function pmpro_bp_lockdown_all_bp() {
 	}
 	
 	// Fixes an issue with BuddyBoss configuration if registration page is set to PMPro + BuddyBoss registration page is set to Levels page.
-	if ( 'pmpro' == $register_page && is_page( $pmpro_pages['levels'] ) ) {
+	if ( 'pmpro' == $register_page && isset( $pmpro_pages['levels'] ) && is_page( $pmpro_pages['levels'] ) ) {
 		return;
 	}
 
@@ -240,7 +240,7 @@ function pmpro_bp_buddypress_or_pmpro_registration() {
 	
 	$pmpro_bp_register = get_option( 'pmpro_bp_registration_page' );
 	
-	if( ! empty( $bp_pages['register'] ) && ! empty( $pmpro_bp_register ) && $pmpro_bp_register == 'buddypress' && isset( $post->ID ) && $post->ID != 0 && $post->ID == $pmpro_pages['levels'] && ! is_user_logged_in() ) {
+	if( ! empty( $bp_pages['register'] ) && ! empty( $pmpro_bp_register ) && $pmpro_bp_register == 'buddypress' && isset( $pmpro_pages['levels'] ) && isset( $post->ID ) && $post->ID != 0 && $post->ID == $pmpro_pages['levels'] && ! is_user_logged_in() ) {
 		// Some cases the BuddyPress/BuddyBoss register page is set to same permalink - causes an error.
 		if ( empty( $bp_pages['register'] ) || get_permalink( $bp_pages['register'] ) === get_permalink( $pmpro_pages['levels'] ) ) {
 			return;
@@ -250,7 +250,7 @@ function pmpro_bp_buddypress_or_pmpro_registration() {
 		wp_redirect( get_permalink( $bp_pages['register'] ) );
 		exit;
 	}
-	elseif( !empty( $pmpro_bp_register ) && $pmpro_bp_register == 'pmpro' && bp_is_register_page() && ! is_page( $pmpro_pages['levels'] ) )
+	elseif( !empty( $pmpro_bp_register ) && $pmpro_bp_register == 'pmpro' && bp_is_register_page() && isset( $pmpro_pages['levels'] ) && ! is_page( $pmpro_pages['levels'] ) )
 	{
 		// Check one last time to make sure the POST ID isn't the same as the levels page.
 		if ( isset( $post->ID ) && $post->ID != 0 && $post->ID == $pmpro_pages['levels'] ) {

--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -252,6 +252,10 @@ function pmpro_bp_buddypress_or_pmpro_registration() {
 	}
 	elseif( !empty( $pmpro_bp_register ) && $pmpro_bp_register == 'pmpro' && bp_is_register_page() && ! is_page( $pmpro_pages['levels'] ) )
 	{
+		// Check one last time to make sure the POST ID isn't the same as the levels page.
+		if ( isset( $post->ID ) && $post->ID != 0 && $post->ID == $pmpro_pages['levels'] ) {
+			return;
+		}
 		//use PMPro Levels page
 		$url = pmpro_url("levels");
 		wp_redirect($url);

--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -192,6 +192,11 @@ function pmpro_bp_lockdown_all_bp() {
 	if ( 'pmpro' == $register_page && is_page( $pmpro_pages['levels'] ) ) {
 		return;
 	}
+
+	// If the registration page is set to use PMPro's and user tries to visit BuddyPress Register/Active just bail and let the redirect to registration function fire.
+	if ( 'pmpro' == $register_page && in_array( bp_current_component(), array( 'register', 'activate' ) ) ) {
+		return;
+	}
 	
 	// Don't redirect awawy from BuddyPress profile pages.
 	if ( bp_is_my_profile() ) {
@@ -245,7 +250,7 @@ function pmpro_bp_buddypress_or_pmpro_registration() {
 		wp_redirect( get_permalink( $bp_pages['register'] ) );
 		exit;
 	}
-	elseif( !empty( $pmpro_bp_register ) && $pmpro_bp_register == 'pmpro' && bp_is_register_page() && ( ! is_page( $pmpro_pages['levels'] ) || $post->ID != $pmpro_pages['levels'] ) )
+	elseif( !empty( $pmpro_bp_register ) && $pmpro_bp_register == 'pmpro' && bp_is_register_page() && ! is_page( $pmpro_pages['levels'] ) )
 	{
 		//use PMPro Levels page
 		$url = pmpro_url("levels");


### PR DESCRIPTION
* BUG FIX: Fixed an issue where in certain cases trying to access the BuddyPress/BuddyBoss set registration page would redirect to "Access Restricted" page. This now redirects these cases to the PMPro's level page.

* BUG FIX: Fixed an issue with too many redirects if set the BuddyPress/BuddyBoss registration page to be the levels page, and set the Paid Memberships Pro BuddyPress setting to use the BuddyPress registration page.

* BUG FIX: Fixed an issue when no page is set inside the BuddyPress/BuddyBoss registration page but set to use the BuddyPress registration page. Do not redirect away from these pages as they may have the registration shortcode on a page, just not have it set in the BuddyPress options.