### PR TITLE
Redirect from the membership levels page only if user not registered when using BuddyPress for site registration.

### DIFF
--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -255,7 +255,7 @@ function pmpro_bp_buddypress_or_pmpro_registration() {
 	if ( $page_setting === 'buddypress' && $on_pmpro_levels ) {
 		// Use the BuddyPress Register page.
 		$bp_pages = get_option( 'bp-pages' );
-		if ( ! empty( $bp_pages['register'] ) ) {
+		if ( ! empty( $bp_pages['register'] ) && ! is_user_logged_in() ) {
 			$url = get_permalink( $bp_pages['register'] );
 		} else {
 			$url = '';


### PR DESCRIPTION
Add additional logic to only redirect a user from the membership levels page if they are not logged in.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

If the Registration Page setting for PMPro BuddyPress Integration settings is set to use BuddyPress registration for user registration we redirect visits to the membership levels page to the BuddyPress registration page. When a user is already registered they are still redirected and not able to visit the membership levels page.

This update changes the behavior to only redirect users that are not logged in, including non-registered visitors, and allows logged-in users access to the membership levels page without being redirected.

### How to test the changes in this Pull Request:

1. Navigate to **Memberships > PMPro BuddyPress**
2. For the _Registration Page_ option set _Use BuddyPress Registration Page_ and save.
3. In a private/incognito browser window register as a new user using the BuddyPress Registration.
4. While logged in as the new user navigate to the Membership Levels page without being redirected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
