### PR TITLE
Removes group status from meta

### DIFF
--- a/includes/groups.php
+++ b/includes/groups.php
@@ -73,3 +73,35 @@ function pmpro_bp_set_member_groups( $level_id, $user_id, $cancel_level = NULL )
 
 }
 add_action( 'pmpro_after_change_membership_level', 'pmpro_bp_set_member_groups', 10, 3 );
+
+/**
+ * Remove the group status in meta if one is present
+ * 
+ * @param  array $group_meta Group meta data
+ * @param  object $group Group data object
+ * @param  bool $is_group If it is a group
+ * @return array
+ */
+function pmpro_bp_nouveau_get_group_meta_custom( $group_meta, $group, $is_group ) {
+
+	if ( isset( $group_meta['status'] ) ) {
+		$group_meta['status'] = '';
+	}
+	
+	return $group_meta;
+
+}
+add_filter( 'bp_nouveau_get_group_meta', 'pmpro_bp_nouveau_get_group_meta_custom', 10, 3 );
+
+/**
+ * Remove the group type if one is present
+ * 
+ * @param  object $group Group data object
+ * @return string
+ */
+function pmpro_bp_get_group_type_custom( $group ) {
+
+	return '';
+
+}
+add_filter( 'bp_get_group_type', 'pmpro_bp_get_group_type_custom' );

--- a/includes/groups.php
+++ b/includes/groups.php
@@ -77,6 +77,8 @@ add_action( 'pmpro_after_change_membership_level', 'pmpro_bp_set_member_groups',
 /**
  * Remove the group status in meta if one is present
  * 
+ * @since TBD
+ * 
  * @param  array $group_meta Group meta data
  * @param  object $group Group data object
  * @param  bool $is_group If it is a group
@@ -96,12 +98,12 @@ add_filter( 'bp_nouveau_get_group_meta', 'pmpro_bp_nouveau_get_group_meta_custom
 /**
  * Remove the group type if one is present
  * 
+ * @since TBD
+ * 
  * @param  object $group Group data object
  * @return string
  */
 function pmpro_bp_get_group_type_custom( $group ) {
-
 	return '';
-
 }
 add_filter( 'bp_get_group_type', 'pmpro_bp_get_group_type_custom' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #78 

### How to test the changes in this Pull Request:

1. Allow the level to give access to viewing group lists
2. The group should not have a group type present such as (Private Group or Public Group

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Group status removed from meta in group and single views
