### PR TITLE
Fix issue for default values not restricting.

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -9,7 +9,7 @@
  */
 function pmpro_bp_get_level_options( $level_id ) {
 	$default_options = array(
-		'pmpro_bp_restrictions'             => 0,
+		'pmpro_bp_restrictions'             => -1, //Default to Lock All BuddyPress for non-members
 		'pmpro_bp_group_creation'           => 0,
 		'pmpro_bp_group_single_viewing'     => 0,
 		'pmpro_bp_groups_page_viewing'      => 0,


### PR DESCRIPTION
BUG FIX: Fix an issue where initial installation wouldn't lock down BuddyPress as per the GUI settings.

Resolves: #67 

Steps to test:

Test this step before applying the patch.

1. Install PMPro BuddyPress (or delete default option 'pmpro_bp_options_users')
2. While logged-out try to view a BuddyPress feature.
