### PR TITLE
Fix issue for BuddyBoss profile page.

### DIFF
--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -292,7 +292,7 @@ function pmpro_bp_show_level_on_bp_profile() {
 	<?php
 	}
 }
-add_filter( 'bp_profile_header_meta', 'pmpro_bp_show_level_on_bp_profile' );
+add_filter( 'bp_before_member_header_meta', 'pmpro_bp_show_level_on_bp_profile' );
 
 /**
  * Restricted message shortcode.


### PR DESCRIPTION
* BUG FIX: Fixes an issue where BuddyBoss theme profile hook wasn't available for showing member's level in their profile. This supports both BuddyPress and BuddyBoss profile pages.

**Screenshots**
BuddyBoss
![buddyboss](https://user-images.githubusercontent.com/12629136/179952119-2b8257c1-5d97-40f5-b4ae-9cab13611895.png)

BuddyPress
![buddypress](https://user-images.githubusercontent.com/12629136/179952128-bdc6d6eb-071b-477d-83d5-e9ed065311bf.png)



