### PR TITLE
Restrict Notifications

### DIFF
--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -301,3 +301,26 @@ function pmpro_bp_restricted_message() {
 	return __('This content is restricted.', 'pmpro-buddypress' ) . ' ';
 }
 add_shortcode( 'pmpro_buddypress_restricted', 'pmpro_bp_restricted_message' );
+
+/**
+ * Restrict viewing of the noifications page or individual
+ * notification pages if the user doesn't have access.
+ */
+function pmpro_bp_restrict_notification_viewing() {
+	
+	global $bp;
+
+	//If BuddyPress is not active, don't worry
+	if( empty( $bp ) ) {
+		return;
+	}
+
+	/**
+	 * If you're restricting group access and want to view the notifications, redirect away
+	 */
+	if ( !pmpro_bp_user_can( 'groups_page_viewing' ) && $bp->current_component == 'notifications' ) {	
+		pmpro_bp_redirect_to_access_required_page();
+	}
+
+}
+add_action( 'template_redirect', 'pmpro_bp_restrict_notification_viewing' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Notifications fall under the groups section. This might require adjustments and more thought. 

If group access is granted and a member visits the Notifications component they will be redirected away. 

Restricting individual notifications don't seem to be possible without removing single page group access.

Resolves #23.

### How to test the changes in this Pull Request:

1. Navigate to the Notifications tab after losing a membership level (from the profile dropdown)
2. You'll be redirected away
3. Trying to view a single notification will be restricted if the group access is resricted

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Notification access is now controlled
