### PR TITLE
Redirect away from directory when no access is granted

### DIFF
--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -172,7 +172,12 @@ add_filter( 'bp_get_add_friend_button', 'pmpro_bp_bp_get_add_friend_button' );
  * Redirect away from any BuddyPress page if set to.
  */
 function pmpro_bp_lockdown_all_bp() {
-	global $current_user, $pmpro_pages;
+	global $bp, $current_user, $pmpro_pages;
+
+	// Return if BuddyPress is not active
+	if( empty( $bp ) ) {
+		return;
+	}
 
 	// Make sure PMPro is active.
 	if ( ! function_exists( 'pmpro_getMembershipLevelForUser' ) ) {
@@ -215,6 +220,12 @@ function pmpro_bp_lockdown_all_bp() {
 	if( $pmpro_bp_options['pmpro_bp_restrictions'] == -1 ) {
 		pmpro_bp_redirect_to_access_required_page();
 	}
+
+	//Redirect away from the members page if no access is allowed
+	if( $bp->current_component == 'members' && pmpro_bp_is_member_directory_locked() ) {
+		pmpro_bp_redirect_to_access_required_page();
+	}
+
 }
 add_action( 'template_redirect', 'pmpro_bp_lockdown_all_bp', 50 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Keeping the directory logic as is and now redirecting away from the directory if you don't have permission to access the content similarly to how we do it with other BP components

Resolves #70 .

### How to test the changes in this Pull Request:

1. Set BP to be completely locked
2. Set a level to grant access to the directory
3. Visit the directory as a visitor that does not have a level - you'll be redirected away 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Redirect away from the Member Directory page when you don't have access to the page
