### PR TITLE
Adjusting the filter and content method added to the Membership tab for BuddyPress user profile

### DIFF
--- a/includes/profiles.php
+++ b/includes/profiles.php
@@ -181,5 +181,6 @@ function pmpro_bp_membership_profile_screen() {
 	 */
 	$content_escaped = apply_filters( 'pmpro_buddypress_profile_account_shortcode', '[pmpro_account]' );
 
+	// phpcs:ignore Content has been escaped within the pmpro_shortcode_account function
 	echo $content_escaped;
 }

--- a/includes/profiles.php
+++ b/includes/profiles.php
@@ -177,9 +177,9 @@ function pmpro_bp_membership_profile_screen() {
 	/**
 	 * Allow filtering the content added to the Membership tab of the BuddyPress profile page.
 	 *
-	 * @param string $content The content to add to the Membership tab of the BuddyPress profile page for current user only.
+	 * @param string $content_escaped The content to add to the Membership tab of the BuddyPress profile page for current user only.
 	 */
-	$content = apply_filters( 'pmpro_buddypress_profile_account_shortcode', '[pmpro_account]' );
+	$content_escaped = apply_filters( 'pmpro_buddypress_profile_account_shortcode', '[pmpro_account]' );
 
-	echo wp_kses_post( $content );
+	echo $content_escaped;
 }

--- a/includes/profiles.php
+++ b/includes/profiles.php
@@ -168,13 +168,18 @@ function pmpro_bp_membership_profile_content() {
 }
 
 /**
- * Callback to return the default shortcode for the account page on the BuddyPress profile page.
+ * Callback to return the default shortcode for the account page on the BuddyPress profile page for current user only.
  *
  * @since 1.3
  * @return string [pmpro_account] Returns the default shortcode screen for Paid Memberships Pro.
  */
 function pmpro_bp_membership_profile_screen() {
-	$shortcode = esc_html( apply_filters( 'pmpro_buddypress_profile_account_shortcode', '[pmpro_account]' ) );
-	
-	echo do_shortcode( "$shortcode" );
+	/**
+	 * Allow filtering the content added to the Membership tab of the BuddyPress profile page.
+	 *
+	 * @param string $content The content to add to the Membership tab of the BuddyPress profile page for current user only.
+	 */
+	$content = apply_filters( 'pmpro_buddypress_profile_account_shortcode', '[pmpro_account]' );
+
+	echo wp_kses_post( $content );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
A user wanted to filter the output content on the BuddyPress User Profile "Membership" tab, but the way this was set up it was forcing to load our Membership Account shortcode and it was not really possible to filter it (add specific "sections" for example).

This update instead sets the content to allow any HTML and runs the output through the wp_kses_post function to allow regular post content formatting, including the do_shortcode function, on the output.
 
 
 Here is an example of using that filter:
 `
/**
 * Adjust the output of the "Membership" tab for BuddyPress Profile.
 */
function my_pmpro_buddypress_profile_account_shortcode( $content ) {
	$content = '[pmpro_account sections="invoices"]';
	return $content;
}
add_filter( 'pmpro_buddypress_profile_account_shortcode', 'my_pmpro_buddypress_profile_account_shortcode' );
`
 
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX/ENHANCEMENT: Adjusted the filter to output content on the Membership tab for the current user profile to allow a shortcode or other HTML content.
 
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
