### PR TITLE
Update headings hierarchy for a11y

### DIFF
--- a/includes/membership-level-settings.php
+++ b/includes/membership-level-settings.php
@@ -27,7 +27,7 @@ function pmpro_bp_level_settings( ) {
 	// Group Settings
 	if ( class_exists( 'BP_Groups_Group' ) ): ?>
 		<hr />
-		<h3><?php _e('BuddyPress Group Membership', 'pmpro-buddypress');?></h3>
+		<h2><?php _e('BuddyPress Group Membership', 'pmpro-buddypress');?></h2>
 		<?php if ( defined( 'BP_PLATFORM_VERSION' ) ) { ?>
 			<p class="description"><?php esc_html_e( 'Note: These settings apply to sites running BuddyPress or BuddyBoss.', 'pmpro-buddypress' ); ?></p>
 		<?php } ?>
@@ -96,7 +96,7 @@ function pmpro_bp_level_settings( ) {
 		</table>
 		<?php endif; ?>
 		<hr />
-		<h3><?php _e('BuddyPress Member Types', 'pmpro-buddypress');?></h3>
+		<h2><?php _e('BuddyPress Member Types', 'pmpro-buddypress');?></h2>
 		<?php if ( defined( 'BP_PLATFORM_VERSION' ) ) { ?>
 			<p class="description"><?php esc_html_e( 'Note: These settings apply to sites running BuddyPress or BuddyBoss.', 'pmpro-buddypress' ); ?></p>
 		<?php } ?>		
@@ -233,7 +233,7 @@ function pmpro_bp_restriction_settings_form( $level_id = NULL) {
 	?>
 	<?php if( $level_id <> 0 ) { ?>
 		<hr />
-		<h3> <?php _e('BuddyPress Restrictions', 'pmpro-buddypress');?></h3>
+		<h2> <?php _e('BuddyPress Restrictions', 'pmpro-buddypress');?></h2>
 	<?php } ?>
 	<?php if ( defined( 'BP_PLATFORM_VERSION' ) ) { ?>
 		<p class="description"><?php esc_html_e( 'Note: These settings apply to sites running BuddyPress or BuddyBoss.', 'pmpro-buddypress' ); ?></p>

--- a/includes/pmpro-buddypress-settings.php
+++ b/includes/pmpro-buddypress-settings.php
@@ -82,7 +82,7 @@ function pmpro_bp_buddpress_admin_page() {
 		<h1><?php esc_attr_e( 'Paid Memberships Pro - BuddyPress & BuddyBoss Add On Settings', 'pmpro-buddypress' ); ?></h1>
 		<p><?php printf( __( 'Restrict access to communities in BuddyPress and BuddyBoss for free or premium members with the Paid Memberships Pro. <strong>This plugin is compatible with both BuddyPress and BuddyBoss.</strong> <a href="%s" target="_blank">Read the documentation</a> for more information about this Add On.', 'pmpro-buddypress' ), 'https://www.paidmembershipspro.com/add-ons/buddypress-integration/?utm_source=plugin&utm_medium=pmpro-buddpress-settings&utm_campaign=pmpro-buddypress' ); ?></p>
 		<hr />
-		<h3><?php esc_attr_e( 'Page Settings', 'pmpro-buddypress' ); ?></h3>
+		<h2><?php esc_attr_e( 'Page Settings', 'pmpro-buddypress' ); ?></h2>
 		<p><?php esc_attr_e( 'This plugin redirects users to a specific page if they try to access restricted features. The user is redirected to the page assigned as the "Access Restricted" page under Memberships > Settings > Page Settings.', 'pmpro-buddypress' ); ?></p>
 		<?php
 			$pmprobp_restricted_page = $pmpro_pages['pmprobp_restricted'];
@@ -97,7 +97,7 @@ function pmpro_bp_buddpress_admin_page() {
 		<p><strong style="color: <?php echo $msgc; ?>"><?php echo $msgt; ?></strong></p>
 		<p><a href="<?php echo admin_url('admin.php?page=pmpro-pagesettings');?>" class="button button-primary"><?php _e('Manage Page Settings', 'paid-memberships-pro' );?></a></p>
 		<hr />
-		<h3><?php esc_attr_e( 'Non-member User Settings', 'pmpro-buddypress' ); ?></h3>
+		<h2><?php esc_attr_e( 'Non-member User Settings', 'pmpro-buddypress' ); ?></h2>
 		<p><?php esc_attr_e( 'Set how BuddyPress should be locked down for users without a membership level.', 'pmpro-buddypress' ); ?></p>
 		<?php 
 			// Settings for Level 0 are for non-member users.
@@ -107,11 +107,11 @@ function pmpro_bp_buddpress_admin_page() {
 			<input name="savesettings" type="submit" class="button button-primary" value="<?php _e('Save All Settings', 'pmpro-buddypress' );?>" />
 		</p>
 		<hr />
-		<h3><?php esc_attr_e( 'Membership Level Settings', 'pmpro-buddypress' ); ?></h3>
+		<h2><?php esc_attr_e( 'Membership Level Settings', 'pmpro-buddypress' ); ?></h2>
 		<p><?php esc_attr_e( 'Edit your membership levels to set level-specific restrictions on community features.', 'pmpro-buddypress' ); ?></p>
 		<p><a href="<?php echo admin_url('admin.php?page=pmpro-membershiplevels');?>" class="button button-primary"><?php _e('Edit Membership Levels', 'paid-memberships-pro' );?></a></p>
 		<hr />		
-		<h3><?php esc_attr_e( 'General Settings', 'pmpro-buddypress' ); ?></h3>
+		<h2><?php esc_attr_e( 'General Settings', 'pmpro-buddypress' ); ?></h2>
 		<?php if ( defined( 'BP_PLATFORM_VERSION' ) ) { ?>
 			<p class="description"><?php esc_html_e( 'Note: These settings apply to sites running BuddyPress or BuddyBoss.', 'pmpro-buddypress' ); ?></p>
 		<?php } ?>


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.