### PR TITLE
Fixed wrong results in BP Profile Search

### DIFF
--- a/includes/directory.php
+++ b/includes/directory.php
@@ -37,10 +37,18 @@ function pmpro_bp_bp_pre_user_query_construct( $query_array ) {
 		if( is_array( $query_array->query_vars['include'] ) ) {
 			// Compute the intersect of members and include value.
 			$query_array->query_vars['include'] = array_intersect( $query_array->query_vars['include'], $pmpro_bp_members_in_directory );
+			if (count ($query_array->query_vars['include']) == 0) {
+				$query_array->query_vars['include'] = array (0); 
+			}
 		} else {
-			// Only include members in the directory.
-			$query_array->query_vars['include'] = $pmpro_bp_members_in_directory;
+			if (is_string($query_array->query_vars['include']) && $query_array->query_vars['include'] == "0") {
+				$query_array->query_vars['include'] = array (0);
+			} else {
+				// Only include members in the directory.
+				$query_array->query_vars['include'] = $pmpro_bp_members_in_directory;
+			}
 		}
+
 	} else {
 		// No members, block the directory.
 		$query_array->query_vars['include'] = array(0);


### PR DESCRIPTION
Fixed the search form results. Instead of zero members it was showing all members.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves The BP Profile Search form results. Instead of zero members it was showing all members.

### How to test the changes in this Pull Request:

1. Make a search which should find no Member. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Fixes BP Profile Search form results. Shows no results found instead of all members.
