### PR TITLE
Fixes #115: Resolve undefined 'link_class' warning for group join button

### DIFF
--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -76,10 +76,15 @@ add_filter( 'bp_user_can_create_groups', 'pmpro_bp_bp_user_can_create_groups', 1
  * Hide the Join Group button if joining groups is restricted
  */
 function pmpro_bp_disable_group_buttons( $button_args, $group ) {			
-	if( ! isset( $button_args['id'] ) || ( $button_args['id'] === 'join_group' || $button_args['id'] === 'request_membership' || $button_args['id'] === 'group_membership' ) && !pmpro_bp_user_can_join_group( $group->id ) ) {
+	if( !pmpro_bp_user_can_join_group( $group->id ) 
+		&& (! isset( $button_args['id'] ) 
+		|| ( $button_args['id'] === 'join_group' 
+		|| $button_args['id'] === 'request_membership' 
+		|| $button_args['id'] === 'group_membership' ) ) ) {
+
 		global $pmpro_pages;
 		$button_args['link_href'] = get_permalink($pmpro_pages['pmprobp_restricted']);
-		$button_args['link_class'] = str_replace( 'join-group', '', $button_args['link_class'] );
+		$button_args['link_class'] = str_replace( 'join-group', '', $button_args['link_class'] ?? '' );
 		$button_args['button_element'] = 'a';
 	}
 


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an issue where a warning (Undefined array key "link_class") is triggered in BuddyBoss groups, caused by the absence of the "link_class" key in PHP 8+. The fix uses a null coalescing operator (??) to provide a default empty value, preventing the warning and maintaining compatibility.

Additionally, the order of conditions within the if statement in the callback function of 'bp_get_group_join_button' (pmpro_bp_disable_group_buttons) was corrected, and parentheses were added to ensure the correct evaluation of conditions. The updated condition checks if the user can join the group first before evaluating the presence and value of $button_args['id'], enhancing both readability and accuracy.


### How to test the changes in this Pull Request:

1. Set up a BuddyBoss group with the Paid Memberships Pro and Paid Memberships Pro - BuddyPress and BuddyBoss Integration.
2. Navigate to the group.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixes PHP 8+ warning for undefined array key "link_class" in the group join button when group joining is restricted. Adjusted the condition order and added parentheses for clarity and correctness in evaluating conditions.