### PR TITLE
Only calling pmpro_bp_get_members_in_directory() when needed

### DIFF
--- a/includes/directory.php
+++ b/includes/directory.php
@@ -9,8 +9,6 @@ function pmpro_bp_directory_init() {
 		return;
 	}
 
-	global $pmpro_bp_members_in_directory;
-	$pmpro_bp_members_in_directory = pmpro_bp_get_members_in_directory();
 	add_action( 'bp_pre_user_query_construct', 'pmpro_bp_bp_pre_user_query_construct', 1, 1 );
 	add_filter( 'bp_get_total_member_count', 'pmpro_bp_bp_get_total_member_count' );
 }
@@ -27,7 +25,7 @@ function pmpro_bp_bp_pre_user_query_construct( $query_array ) {
 		return;
 	}
 
-	global $pmpro_bp_members_in_directory;
+	$pmpro_bp_members_in_directory = pmpro_bp_get_members_in_directory();
 	if( !empty( $pmpro_bp_members_in_directory ) ) {
 		// If an include value was already set, make sure it's in array form.
 		if( !empty( $query_array->query_vars['include'] ) && !is_array( $query_array->query_vars['include']) ) {
@@ -48,23 +46,28 @@ function pmpro_bp_bp_pre_user_query_construct( $query_array ) {
 }
 
 function pmpro_bp_bp_get_total_member_count($count) {
-	global $pmpro_bp_members_in_directory;
-
-	$count = count($pmpro_bp_members_in_directory);
+	$count = count( pmpro_bp_get_members_in_directory() );
 	return $count;
 }
 
 function pmpro_bp_get_members_in_directory() {
 	global $wpdb, $pmpro_levels;
 
+	static $include_users = null;
+	if ( ! is_null( $include_users ) ) {
+		return $include_users;
+	}
+
 	if( !function_exists( 'pmpro_getAllLevels' ) ) {
-		return array();
+		$include_users = array();
+		return $include_users;
 	}
 
 	$pmpro_levels = pmpro_getAllLevels(true, true);
 	
 	if ( empty( $pmpro_levels ) ) {
-		return array();
+		$include_users = array();
+		return $include_users;
 	}
 
 	//see if we should include them in the member directory.
@@ -79,7 +82,8 @@ function pmpro_bp_get_members_in_directory() {
 	}
 	
 	if ( empty( $include_levels ) ) {
-		return array();
+		$include_users = array();
+		return $include_users;
 	}
 
 	$sql_parts = array();

--- a/includes/directory.php
+++ b/includes/directory.php
@@ -51,7 +51,7 @@ function pmpro_bp_bp_get_total_member_count($count) {
 }
 
 function pmpro_bp_get_members_in_directory() {
-	global $wpdb, $pmpro_levels;
+	global $wpdb, $pmpro_levels, $pmpro_bp_members_in_directory;
 
 	static $include_users = null;
 	if ( ! is_null( $include_users ) ) {
@@ -60,6 +60,7 @@ function pmpro_bp_get_members_in_directory() {
 
 	if( !function_exists( 'pmpro_getAllLevels' ) ) {
 		$include_users = array();
+		$pmpro_bp_members_in_directory = $include_users; // For backwards compatibility.
 		return $include_users;
 	}
 
@@ -67,6 +68,7 @@ function pmpro_bp_get_members_in_directory() {
 	
 	if ( empty( $pmpro_levels ) ) {
 		$include_users = array();
+		$pmpro_bp_members_in_directory = $include_users; // For backwards compatibility.
 		return $include_users;
 	}
 
@@ -83,6 +85,7 @@ function pmpro_bp_get_members_in_directory() {
 	
 	if ( empty( $include_levels ) ) {
 		$include_users = array();
+		$pmpro_bp_members_in_directory = $include_users; // For backwards compatibility.
 		return $include_users;
 	}
 
@@ -117,6 +120,8 @@ function pmpro_bp_get_members_in_directory() {
 	$wpdb->flush();
 	
 	$include_users = $wpdb->get_col( $sqlQuery );
+
+	$pmpro_bp_members_in_directory = $include_users; // For backwards compatibility.
 
 	return $include_users;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Prevents running a query on `init` when it is not needed. Needs testing to ensure that the directory still works as expected.

Note: If the `$pmpro_bp_members_in_directory` global is being used in custom code before `pmpro_bp_get_members_in_directory()` is called, that custom code may break. The solution is using the `pmpro_bp_get_members_in_directory()` function instead of the global variable.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
