### PR TITLE
xProfile field visibility not set to defaults after PMPro signup

### DIFF
--- a/includes/profiles.php
+++ b/includes/profiles.php
@@ -28,8 +28,13 @@ function pmpro_bp_update_user_meta( $meta_id, $user_id, $meta_key, $meta_value )
 				$x_field = xprofile_get_field_id_from_name( $rh_field->buddypress );
 
 				if( !empty( $x_field ) ) {
+					// Get the current visibility for the xprofile field. If not set, this will get the default.
 					$x_field_visibility = xprofile_get_field_visibility_level( $x_field, $user_id );
+
+					// Update the xprofile field visibility.
 					xprofile_set_field_visibility_level( $x_field, $user_id, $x_field_visibility );
+
+					// Update the xprofile field data.
 					xprofile_set_field_data( $x_field, $user_id, $meta_value );
 				}
 			}

--- a/includes/profiles.php
+++ b/includes/profiles.php
@@ -22,16 +22,17 @@ function pmpro_bp_update_user_meta( $meta_id, $user_id, $meta_key, $meta_value )
 	{
 		foreach( $field_location as $rh_field )
 		{
-			if( $rh_field->meta_key == $meta_key && !empty( $rh_field->buddypress ) )
-			{
+			if( $rh_field->meta_key == $meta_key && !empty( $rh_field->buddypress ) ) {
 				//switch for type
 				
 				$x_field = xprofile_get_field_id_from_name( $rh_field->buddypress );
 
-				if( !empty( $x_field ) )
+				if( !empty( $x_field ) ) {
+					$x_field_visibility = xprofile_get_field_visibility_level( $x_field, $user_id );
+					xprofile_set_field_visibility_level( $x_field, $user_id, $x_field_visibility );
 					xprofile_set_field_data( $x_field, $user_id, $meta_value );
+				}
 			}
-				
 		}
 	}
 }


### PR DESCRIPTION
 * Set field visibility when syncing.
 
<img width="1723" alt="Screenshot 2025-02-13 at 2 17 44 PM" src="https://github.com/user-attachments/assets/21bf8fbb-48f3-4756-8fa2-c31607cbf46d" />
<img width="906" alt="Screenshot 2025-02-13 at 2 28 56 PM" src="https://github.com/user-attachments/assets/18c2970f-c759-4074-a5ad-d6762d9f76d7" />
<img width="1254" alt="Screenshot 2025-02-13 at 2 29 44 PM" src="https://github.com/user-attachments/assets/ceedca06-182c-421d-a6d8-ce0d74f9feaf" />


### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When syncing user fields and xProfile fields retrieve the default visibility and set it again when syncing.

Resolves #74 .

### How to test the changes in this Pull Request:

Follow steps in bug above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
