### PR TITLE
Warning displays before joining a BuddyBoss group

### DIFF
--- a/includes/restrictions.php
+++ b/includes/restrictions.php
@@ -75,7 +75,11 @@ add_filter( 'bp_user_can_create_groups', 'pmpro_bp_bp_user_can_create_groups', 1
 /**
  * Hide the Join Group button if joining groups is restricted
  */
-function pmpro_bp_disable_group_buttons( $button_args, $group ) {			
+function pmpro_bp_disable_group_buttons( $button_args, $group ) {
+	//Bail if $button_args isn't an array. Something went wrong.
+	if( ! is_array( $button_args ) ) {
+		return $button_args;
+	}
 	if( ! isset( $button_args['id'] ) || ( $button_args['id'] === 'join_group' || $button_args['id'] === 'request_membership' || $button_args['id'] === 'group_membership' ) && !pmpro_bp_user_can_join_group( $group->id ) ) {
 		global $pmpro_pages;
 		$button_args['link_href'] = get_permalink($pmpro_pages['pmprobp_restricted']);


### PR DESCRIPTION
 * Bail if filter callback param supposed to be an array and have 'link_class' doesn't have. Something went wrong. Read source code and currently seems not possible but users reported in the past. Likely something buggy in budyboss end.
 
 https://github.com/buddyboss/buddyboss-platform/blob/2.7.91/src/bp-groups/bp-groups-template.php#L4359-L4485

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #115 .

### How to test the changes in this Pull Request:

Couldn't reproduce. In order to try to reproduce to at least trigger the filter callback and hide the button need to set up a group and make it restricted by level from PMPro Level settings. In my test everything went ok.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
