### PR TITLE
Add Xprofile field mapping settings and restructure the settings page

### DIFF
--- a/includes/pmpro-buddypress-settings.php
+++ b/includes/pmpro-buddypress-settings.php
@@ -26,25 +26,31 @@ function pmpro_bp_buddpress_admin_page() {
 
 	global $pmpro_pages, $msg, $msgt;
 
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have permission to access this page.', 'pmpro-buddypress' ) );
+	}
+
 	//get/set settings
-	if(!empty($_REQUEST['savesettings'])) {
+	if ( ! empty( $_POST['savesettings'] ) ) {
+		check_admin_referer( 'pmpro_bp_save_settings', 'pmpro_bp_settings_nonce' );
+
 		// Non-member user Restrictions
-		$can_create_groups = intval( $_REQUEST['pmpro_bp_group_creation'] );
-		$can_view_single_group = intval( $_REQUEST['pmpro_bp_group_single_viewing'] );
-		$can_view_groups_page = intval( $_REQUEST['pmpro_bp_groups_page_viewing'] );
-		$can_join_groups = intval( $_REQUEST['pmpro_bp_groups_join'] );
-		$pmpro_bp_restrictions = intval( $_REQUEST['pmpro_bp_restrictions'] );
-		$pmpro_bp_public_messaging = intval( $_REQUEST['pmpro_bp_public_messaging'] );
-		$pmpro_bp_private_messaging = intval( $_REQUEST['pmpro_bp_private_messaging'] );
-		$pmpro_bp_send_friend_request = intval( $_REQUEST['pmpro_bp_send_friend_request'] );
-		$pmpro_bp_member_directory = intval( $_REQUEST['pmpro_bp_member_directory'] );		
-			
+		$can_create_groups = isset( $_POST['pmpro_bp_group_creation'] ) ? intval( $_POST['pmpro_bp_group_creation'] ) : 0;
+		$can_view_single_group = isset( $_POST['pmpro_bp_group_single_viewing'] ) ? intval( $_POST['pmpro_bp_group_single_viewing'] ) : 0;
+		$can_view_groups_page = isset( $_POST['pmpro_bp_groups_page_viewing'] ) ? intval( $_POST['pmpro_bp_groups_page_viewing'] ) : 0;
+		$can_join_groups = isset( $_POST['pmpro_bp_groups_join'] ) ? intval( $_POST['pmpro_bp_groups_join'] ) : 0;
+		$pmpro_bp_restrictions = isset( $_POST['pmpro_bp_restrictions'] ) ? intval( $_POST['pmpro_bp_restrictions'] ) : 0;
+		$pmpro_bp_public_messaging = isset( $_POST['pmpro_bp_public_messaging'] ) ? intval( $_POST['pmpro_bp_public_messaging'] ) : 0;
+		$pmpro_bp_private_messaging = isset( $_POST['pmpro_bp_private_messaging'] ) ? intval( $_POST['pmpro_bp_private_messaging'] ) : 0;
+		$pmpro_bp_send_friend_request = isset( $_POST['pmpro_bp_send_friend_request'] ) ? intval( $_POST['pmpro_bp_send_friend_request'] ) : 0;
+		$pmpro_bp_member_directory = isset( $_POST['pmpro_bp_member_directory'] ) ? intval( $_POST['pmpro_bp_member_directory'] ) : 0;
+
 		$pmpro_bp_options = array(
 			'pmpro_bp_restrictions'				=> $pmpro_bp_restrictions,
 			'pmpro_bp_group_creation'			=> $can_create_groups,
 			'pmpro_bp_group_single_viewing'		=> $can_view_single_group,
 			'pmpro_bp_groups_page_viewing'		=> $can_view_groups_page,
-			'pmpro_bp_groups_join'				=> $can_join_groups,			
+			'pmpro_bp_groups_join'				=> $can_join_groups,
 			'pmpro_bp_private_messaging'		=> $pmpro_bp_private_messaging,
 			'pmpro_bp_public_messaging'			=> $pmpro_bp_public_messaging,
 			'pmpro_bp_send_friend_request'		=> $pmpro_bp_send_friend_request,
@@ -55,102 +61,151 @@ function pmpro_bp_buddpress_admin_page() {
 		update_option('pmpro_bp_options_users', $pmpro_bp_options, 'no');
 
 		// General Settings
-		update_option( 'pmpro_bp_registration_page', $_POST['pmpro_bp_register'] );
-		update_option( 'pmpro_bp_show_level_on_bp_profile', $_POST['pmpro_bp_level_profile'], 'no' ) ;
+		update_option( 'pmpro_bp_registration_page', isset( $_POST['pmpro_bp_register'] ) ? sanitize_text_field( wp_unslash( $_POST['pmpro_bp_register'] ) ) : 'pmpro' );
+		update_option( 'pmpro_bp_show_level_on_bp_profile', isset( $_POST['pmpro_bp_level_profile'] ) ? sanitize_text_field( wp_unslash( $_POST['pmpro_bp_level_profile'] ) ) : 'yes', 'no' );
 
-		// Xprofile Field Mapping (saves only if its section nonce verifies).
+		// Xprofile Field Mapping
 		pmpro_bp_save_xprofile_field_map();
 
 		// Assume Success
 		$msg = 1;
 		$msgt = __( 'Your settings have been updated.', 'pmpro-buddypress' );
 	}
-	
+
     $pmpro_bp_register = get_option( 'pmpro_bp_registration_page' );
     $pmpro_bp_level_profile = get_option( 'pmpro_bp_show_level_on_bp_profile' );
-    
+
 	if( empty( $pmpro_bp_register ) ) {
-		$pmpro_bp_register = 'pmpro'; //default to the PMPro Levels page 
+		$pmpro_bp_register = 'pmpro'; //default to the PMPro Levels page
 	}
-    
+
 	if( empty( $pmpro_bp_level_profile ) ) {
-		$pmpro_bp_level_profile = 'yes'; //default to showing Level on BuddyPress Profile 
+		$pmpro_bp_level_profile = 'yes'; //default to showing Level on BuddyPress Profile
 	}
 
 	require_once( PMPRO_DIR . '/adminpages/admin_header.php' ); ?>
 
-	<div id="poststuff">
-		<form action="" method="post" enctype="multipart/form-data">
+	<form action="" method="post">
+		<?php wp_nonce_field( 'pmpro_bp_save_settings', 'pmpro_bp_settings_nonce' ); ?>
+		<hr class="wp-header-end">
+		<h1><?php esc_html_e( 'Paid Memberships Pro - BuddyPress & BuddyBoss Add On Settings', 'pmpro-buddypress' ); ?></h1>
+		<p><?php printf( __( 'Restrict access to communities in BuddyPress and BuddyBoss for free or premium members with Paid Memberships Pro. <strong>This plugin is compatible with both BuddyPress and BuddyBoss.</strong> <a href="%s" target="_blank">Read the documentation</a> for more information about this Add On.', 'pmpro-buddypress' ), 'https://www.paidmembershipspro.com/add-ons/buddypress-integration/?utm_source=plugin&utm_medium=pmpro-buddpress-settings&utm_campaign=pmpro-buddypress' ); ?></p>
 
-		<h1><?php esc_attr_e( 'Paid Memberships Pro - BuddyPress & BuddyBoss Add On Settings', 'pmpro-buddypress' ); ?></h1>
-		<p><?php printf( __( 'Restrict access to communities in BuddyPress and BuddyBoss for free or premium members with the Paid Memberships Pro. <strong>This plugin is compatible with both BuddyPress and BuddyBoss.</strong> <a href="%s" target="_blank">Read the documentation</a> for more information about this Add On.', 'pmpro-buddypress' ), 'https://www.paidmembershipspro.com/add-ons/buddypress-integration/?utm_source=plugin&utm_medium=pmpro-buddpress-settings&utm_campaign=pmpro-buddypress' ); ?></p>
-		<hr />
-		<h3><?php esc_attr_e( 'Page Settings', 'pmpro-buddypress' ); ?></h3>
-		<p><?php esc_attr_e( 'This plugin redirects users to a specific page if they try to access restricted features. The user is redirected to the page assigned as the "Access Restricted" page under Memberships > Settings > Page Settings.', 'pmpro-buddypress' ); ?></p>
-		<?php
-			$pmprobp_restricted_page = $pmpro_pages['pmprobp_restricted'];
-			if ( ! empty( $pmprobp_restricted_page ) ) {
-				$msgt = '<span class="dashicons dashicons-yes"></span>' . esc_attr__( '"Access Restricted" page is configured.', 'pmpro-buddypress' );
-				$msgc = '#46b450';
-			} else {
-				$msgt = '<span class="dashicons dashicons-no"></span>' . esc_attr__( '"Access Restricted" page is not configured.', 'pmpro-buddypress' );
-				$msgc = '#a00';
-			}
-		?>
-		<p><strong style="color: <?php echo $msgc; ?>"><?php echo $msgt; ?></strong></p>
-		<p><a href="<?php echo admin_url('admin.php?page=pmpro-pagesettings');?>" class="button button-primary"><?php _e('Manage Page Settings', 'paid-memberships-pro' );?></a></p>
-		<hr />
-		<h3><?php esc_attr_e( 'Non-member User Settings', 'pmpro-buddypress' ); ?></h3>
-		<p><?php esc_attr_e( 'Set how BuddyPress should be locked down for users without a membership level.', 'pmpro-buddypress' ); ?></p>
-		<?php 
-			// Settings for Level 0 are for non-member users.
-			pmpro_bp_restriction_settings_form(0);
-		?>
-		<p class="submit">
-			<input name="savesettings" type="submit" class="button button-primary" value="<?php _e('Save All Settings', 'pmpro-buddypress' );?>" />
-		</p>
-		<hr />
-		<h3><?php esc_attr_e( 'Membership Level Settings', 'pmpro-buddypress' ); ?></h3>
-		<p><?php esc_attr_e( 'Edit your membership levels to set level-specific restrictions on community features.', 'pmpro-buddypress' ); ?></p>
-		<p><a href="<?php echo admin_url('admin.php?page=pmpro-membershiplevels');?>" class="button button-primary"><?php _e('Edit Membership Levels', 'paid-memberships-pro' );?></a></p>
-		<hr />		
-		<h3><?php esc_attr_e( 'General Settings', 'pmpro-buddypress' ); ?></h3>
-		<?php if ( defined( 'BP_PLATFORM_VERSION' ) ) { ?>
-			<p class="description"><?php esc_html_e( 'Note: These settings apply to sites running BuddyPress or BuddyBoss.', 'pmpro-buddypress' ); ?></p>
-		<?php } ?>
-		<table class="form-table">
-		<tbody>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="pmpro_bp_register"><?php _e("Registration Page", 'pmpro-buddypress');?></label>
-				</th>
-				<td>
-					<select id="pmpro_bp_register" name="pmpro_bp_register">
-						<option value="pmpro" <?php if($pmpro_bp_register == 'pmpro') { ?>selected="selected"<?php } ?>><?php _e('Use PMPro Levels Page', 'pmpro-buddypress');?></option>
-						<option value="buddypress" <?php if($pmpro_bp_register == 'buddypress') { ?>selected="selected"<?php } ?>><?php _e('Use BuddyPress Registration Page', 'pmpro-buddypress');?></option>
-					</select>
-				</td>
-			</tr>
-			
-			<tr>
-				<th scope="row" valign="top">
-					<label for="pmpro_bp_level_profile"><?php _e("Show Membership Level on Profiles?", 'pmpro-buddypress');?></label>
-				</th>
-				<td>
-					<select id="pmpro_bp_level_profile" name="pmpro_bp_level_profile">
-						<option value="yes" <?php if($pmpro_bp_level_profile == 'yes') { ?>selected="selected"<?php } ?>><?php _e('Yes', 'pmpro-buddypress');?></option>
-						<option value="no" <?php if($pmpro_bp_level_profile == 'no') { ?>selected="selected"<?php } ?>><?php _e('No', 'pmpro-buddypress');?></option>
-					</select>
-				</td>
-			</tr>
-		</tbody>
-		</table>
-		<hr />
-		<?php pmpro_bp_render_xprofile_mapping_section(); ?>
-		<p class="submit">
-			<input name="savesettings" type="submit" class="button button-primary" value="<?php _e('Save All Settings', 'pmpro-buddypress');?>" />
-		</p>
+		<div id="pmpro-bp-page-settings" class="pmpro_section" data-visibility="shown" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
+					<span class="dashicons dashicons-arrow-up-alt2"></span>
+					<?php esc_html_e( 'Page Settings', 'pmpro-buddypress' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside">
+				<p><?php esc_html_e( 'This plugin redirects users to a specific page if they try to access restricted features. The user is redirected to the page assigned as the "Access Restricted" page under Memberships > Settings > Page Settings.', 'pmpro-buddypress' ); ?></p>
+				<?php
+					$pmprobp_restricted_page = $pmpro_pages['pmprobp_restricted'];
+					if ( ! empty( $pmprobp_restricted_page ) ) {
+						$page_msgt = '<span class="dashicons dashicons-yes"></span>' . esc_html__( '"Access Restricted" page is configured.', 'pmpro-buddypress' );
+						$page_msgc = '#46b450';
+					} else {
+						$page_msgt = '<span class="dashicons dashicons-no"></span>' . esc_html__( '"Access Restricted" page is not configured.', 'pmpro-buddypress' );
+						$page_msgc = '#a00';
+					}
+				?>
+				<p><strong style="color: <?php echo esc_attr( $page_msgc ); ?>"><?php echo $page_msgt; ?></strong></p>
+				<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-pagesettings' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Manage Page Settings', 'pmpro-buddypress' ); ?></a></p>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
 
-		</form>
-<?php
+		<div id="pmpro-bp-non-member-settings" class="pmpro_section" data-visibility="hidden" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
+					<span class="dashicons dashicons-arrow-down-alt2"></span>
+					<?php esc_html_e( 'Non-member User Settings', 'pmpro-buddypress' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside" style="display: none;">
+				<p><?php esc_html_e( 'Set how BuddyPress should be locked down for users without a membership level.', 'pmpro-buddypress' ); ?></p>
+				<?php
+					// Settings for Level 0 are for non-member users.
+					pmpro_bp_restriction_settings_form(0);
+				?>
+				<p class="submit">
+					<input name="savesettings" type="submit" class="button button-primary" value="<?php esc_attr_e( 'Save All Settings', 'pmpro-buddypress' ); ?>" />
+				</p>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
+
+		<div id="pmpro-bp-level-settings" class="pmpro_section" data-visibility="hidden" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
+					<span class="dashicons dashicons-arrow-down-alt2"></span>
+					<?php esc_html_e( 'Membership Level Settings', 'pmpro-buddypress' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside" style="display: none;">
+				<p><?php esc_html_e( 'Edit your membership levels to set level-specific restrictions on community features.', 'pmpro-buddypress' ); ?></p>
+				<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-membershiplevels' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Edit Membership Levels', 'pmpro-buddypress' ); ?></a></p>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
+
+		<div id="pmpro-bp-general-settings" class="pmpro_section" data-visibility="hidden" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
+					<span class="dashicons dashicons-arrow-down-alt2"></span>
+					<?php esc_html_e( 'General Settings', 'pmpro-buddypress' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside" style="display: none;">
+				<?php if ( defined( 'BP_PLATFORM_VERSION' ) ) { ?>
+					<p class="description"><?php esc_html_e( 'Note: These settings apply to sites running BuddyPress or BuddyBoss.', 'pmpro-buddypress' ); ?></p>
+				<?php } ?>
+				<table class="form-table">
+				<tbody>
+					<tr>
+						<th scope="row" valign="top">
+							<label for="pmpro_bp_register"><?php esc_html_e( 'Registration Page', 'pmpro-buddypress' ); ?></label>
+						</th>
+						<td>
+							<select id="pmpro_bp_register" name="pmpro_bp_register">
+								<option value="pmpro" <?php selected( $pmpro_bp_register, 'pmpro' ); ?>><?php esc_html_e( 'Use PMPro Levels Page', 'pmpro-buddypress' ); ?></option>
+								<option value="buddypress" <?php selected( $pmpro_bp_register, 'buddypress' ); ?>><?php esc_html_e( 'Use BuddyPress Registration Page', 'pmpro-buddypress' ); ?></option>
+							</select>
+						</td>
+					</tr>
+
+					<tr>
+						<th scope="row" valign="top">
+							<label for="pmpro_bp_level_profile"><?php esc_html_e( 'Show Membership Level on Profiles?', 'pmpro-buddypress' ); ?></label>
+						</th>
+						<td>
+							<select id="pmpro_bp_level_profile" name="pmpro_bp_level_profile">
+								<option value="yes" <?php selected( $pmpro_bp_level_profile, 'yes' ); ?>><?php esc_html_e( 'Yes', 'pmpro-buddypress' ); ?></option>
+								<option value="no" <?php selected( $pmpro_bp_level_profile, 'no' ); ?>><?php esc_html_e( 'No', 'pmpro-buddypress' ); ?></option>
+							</select>
+						</td>
+					</tr>
+				</tbody>
+				</table>
+				<p class="submit">
+					<input name="savesettings" type="submit" class="button button-primary" value="<?php esc_attr_e( 'Save All Settings', 'pmpro-buddypress' ); ?>" />
+				</p>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
+
+		<div id="pmpro-bp-xprofile-mapping" class="pmpro_section" data-visibility="hidden" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
+					<span class="dashicons dashicons-arrow-down-alt2"></span>
+					<?php esc_html_e( 'Xprofile Field Mapping', 'pmpro-buddypress' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside" style="display: none;">
+				<?php pmpro_bp_render_xprofile_mapping_section(); ?>
+				<p class="submit">
+					<input name="savesettings" type="submit" class="button button-primary" value="<?php esc_attr_e( 'Save All Settings', 'pmpro-buddypress' ); ?>" />
+				</p>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
+	</form>
+	<?php
+	require_once( PMPRO_DIR . '/adminpages/admin_footer.php' );
 }

--- a/includes/pmpro-buddypress-settings.php
+++ b/includes/pmpro-buddypress-settings.php
@@ -142,8 +142,85 @@ function pmpro_bp_buddpress_admin_page() {
 				</button>
 			</div>
 			<div class="pmpro_section_inside" style="display: none;">
-				<p><?php esc_html_e( 'Edit your membership levels to set level-specific restrictions on community features.', 'pmpro-buddypress' ); ?></p>
-				<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-membershiplevels' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Edit Membership Levels', 'pmpro-buddypress' ); ?></a></p>
+				<p><?php esc_html_e( 'Edit your membership levels to set level-specific restrictions on community features. These settings are managed in the "BuddyPress Restrictions" section when editing a membership level.', 'pmpro-buddypress' ); ?></p>
+				<?php
+					$pmpro_bp_levels = pmpro_getAllLevels( true, true );
+					if ( function_exists( 'pmpro_sort_levels_by_order' ) ) {
+						$pmpro_bp_levels = pmpro_sort_levels_by_order( $pmpro_bp_levels );
+					}
+				?>
+				<?php if ( empty( $pmpro_bp_levels ) ) { ?>
+					<p><strong><?php esc_html_e( 'No membership levels found.', 'pmpro-buddypress' ); ?></strong> <a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-membershiplevels' ) ); ?>"><?php esc_html_e( 'Create a membership level to get started.', 'pmpro-buddypress' ); ?></a></p>
+				<?php } else { ?>
+					<table class="widefat striped">
+						<thead>
+							<tr>
+								<th scope="col"><?php esc_html_e( 'Level', 'pmpro-buddypress' ); ?></th>
+								<th scope="col"><?php esc_html_e( 'BuddyPress Access', 'pmpro-buddypress' ); ?></th>
+								<th scope="col"><?php esc_html_e( 'Member Types', 'pmpro-buddypress' ); ?></th>
+								<th scope="col"><?php esc_html_e( 'Auto-Join Groups', 'pmpro-buddypress' ); ?></th>
+								<th scope="col"><?php esc_html_e( 'Actions', 'pmpro-buddypress' ); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ( $pmpro_bp_levels as $pmpro_bp_level ) { ?>
+								<?php
+									// Read the raw per-level option so "use non-member settings" is
+									// reported as such instead of being resolved to its effective values.
+									$level_options = get_option( 'pmpro_bp_options_' . $pmpro_bp_level->id, array() );
+									$level_options = array_merge( pmpro_bp_get_level_options( -1 ), (array) $level_options );
+
+									switch ( (int) $level_options['pmpro_bp_restrictions'] ) {
+										case PMPROBP_USE_NON_MEMBER_SETTINGS:
+											$access_label = __( 'Uses non-member user settings', 'pmpro-buddypress' );
+											break;
+										case PMPROBP_GIVE_ALL_ACCESS:
+											$access_label = __( 'All of BuddyPress unlocked', 'pmpro-buddypress' );
+											break;
+										case PMPROBP_SPECIFIC_FEATURES:
+											$feature_keys = array( 'pmpro_bp_group_creation', 'pmpro_bp_group_single_viewing', 'pmpro_bp_groups_page_viewing', 'pmpro_bp_groups_join', 'pmpro_bp_private_messaging', 'pmpro_bp_public_messaging', 'pmpro_bp_send_friend_request', 'pmpro_bp_member_directory' );
+											$enabled      = 0;
+											foreach ( $feature_keys as $feature_key ) {
+												if ( ! empty( $level_options[ $feature_key ] ) ) {
+													$enabled++;
+												}
+											}
+											// translators: %1$d is the number of unlocked features, %2$d is the total number of features.
+											$access_label = sprintf( __( 'Partial access (%1$d of %2$d features unlocked)', 'pmpro-buddypress' ), $enabled, count( $feature_keys ) );
+											break;
+										case PMPROBP_LOCK_ALL_ACCESS:
+										default:
+											$access_label = __( 'All of BuddyPress locked', 'pmpro-buddypress' );
+											break;
+									}
+
+									// Member type names for this level.
+									$member_type_names = array();
+									foreach ( (array) $level_options['pmpro_bp_member_types'] as $member_type ) {
+										$member_type_object  = function_exists( 'bp_get_member_type_object' ) ? bp_get_member_type_object( $member_type ) : null;
+										$member_type_names[] = ! empty( $member_type_object->labels['singular_name'] ) ? $member_type_object->labels['singular_name'] : $member_type;
+									}
+
+									// Group names this level is automatically added to.
+									$group_names = array();
+									foreach ( (array) $level_options['pmpro_bp_group_automatic_add'] as $group_id ) {
+										$group         = function_exists( 'groups_get_group' ) ? groups_get_group( $group_id ) : null;
+										$group_names[] = ! empty( $group->name ) ? $group->name : '#' . (int) $group_id;
+									}
+
+									$level_edit_url = admin_url( 'admin.php?page=pmpro-membershiplevels&edit=' . (int) $pmpro_bp_level->id );
+								?>
+								<tr>
+									<td><a href="<?php echo esc_url( $level_edit_url ); ?>" target="_blank"><?php echo esc_html( $pmpro_bp_level->name ); ?></a></td>
+									<td><?php echo esc_html( $access_label ); ?></td>
+									<td><?php echo ! empty( $member_type_names ) ? esc_html( implode( ', ', $member_type_names ) ) : '&#8212;'; ?></td>
+									<td><?php echo ! empty( $group_names ) ? esc_html( implode( ', ', $group_names ) ) : '&#8212;'; ?></td>
+									<td><a href="<?php echo esc_url( $level_edit_url ); ?>" target="_blank"><?php esc_html_e( 'Edit Level', 'pmpro-buddypress' ); ?></a></td>
+								</tr>
+							<?php } ?>
+						</tbody>
+					</table>
+				<?php } ?>
 			</div> <!-- end pmpro_section_inside -->
 		</div> <!-- end pmpro_section -->
 

--- a/includes/pmpro-buddypress-settings.php
+++ b/includes/pmpro-buddypress-settings.php
@@ -61,8 +61,17 @@ function pmpro_bp_buddpress_admin_page() {
 		update_option('pmpro_bp_options_users', $pmpro_bp_options, 'no');
 
 		// General Settings
-		update_option( 'pmpro_bp_registration_page', isset( $_POST['pmpro_bp_register'] ) ? sanitize_text_field( wp_unslash( $_POST['pmpro_bp_register'] ) ) : 'pmpro' );
-		update_option( 'pmpro_bp_show_level_on_bp_profile', isset( $_POST['pmpro_bp_level_profile'] ) ? sanitize_text_field( wp_unslash( $_POST['pmpro_bp_level_profile'] ) ) : 'yes', 'no' );
+		$register_value = isset( $_POST['pmpro_bp_register'] ) ? sanitize_text_field( wp_unslash( $_POST['pmpro_bp_register'] ) ) : 'buddypress';
+		if ( ! in_array( $register_value, array( 'pmpro', 'buddypress' ), true ) ) {
+			$register_value = 'buddypress';
+		}
+		update_option( 'pmpro_bp_registration_page', $register_value );
+
+		$level_profile_value = isset( $_POST['pmpro_bp_level_profile'] ) ? sanitize_text_field( wp_unslash( $_POST['pmpro_bp_level_profile'] ) ) : 'no';
+		if ( ! in_array( $level_profile_value, array( 'yes', 'no' ), true ) ) {
+			$level_profile_value = 'no';
+		}
+		update_option( 'pmpro_bp_show_level_on_bp_profile', $level_profile_value, 'no' );
 
 		// Xprofile Field Mapping
 		pmpro_bp_save_xprofile_field_map();

--- a/includes/pmpro-buddypress-settings.php
+++ b/includes/pmpro-buddypress-settings.php
@@ -195,7 +195,7 @@ function pmpro_bp_buddpress_admin_page() {
 			<div class="pmpro_section_toggle">
 				<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
 					<span class="dashicons dashicons-arrow-down-alt2"></span>
-					<?php esc_html_e( 'Xprofile Field Mapping', 'pmpro-buddypress' ); ?>
+					<?php esc_html_e( 'Extended Profile Field Mapping', 'pmpro-buddypress' ); ?>
 				</button>
 			</div>
 			<div class="pmpro_section_inside" style="display: none;">

--- a/includes/pmpro-buddypress-settings.php
+++ b/includes/pmpro-buddypress-settings.php
@@ -58,6 +58,9 @@ function pmpro_bp_buddpress_admin_page() {
 		update_option( 'pmpro_bp_registration_page', $_POST['pmpro_bp_register'] );
 		update_option( 'pmpro_bp_show_level_on_bp_profile', $_POST['pmpro_bp_level_profile'], 'no' ) ;
 
+		// Xprofile Field Mapping (saves only if its section nonce verifies).
+		pmpro_bp_save_xprofile_field_map();
+
 		// Assume Success
 		$msg = 1;
 		$msgt = __( 'Your settings have been updated.', 'pmpro-buddypress' );
@@ -141,7 +144,9 @@ function pmpro_bp_buddpress_admin_page() {
 				</td>
 			</tr>
 		</tbody>
-		</table>		
+		</table>
+		<hr />
+		<?php pmpro_bp_render_xprofile_mapping_section(); ?>
 		<p class="submit">
 			<input name="savesettings" type="submit" class="button button-primary" value="<?php _e('Save All Settings', 'pmpro-buddypress');?>" />
 		</p>

--- a/includes/pmpro-buddypress-settings.php
+++ b/includes/pmpro-buddypress-settings.php
@@ -170,12 +170,15 @@ function pmpro_bp_buddpress_admin_page() {
 									$level_options = get_option( 'pmpro_bp_options_' . $pmpro_bp_level->id, array() );
 									$level_options = array_merge( pmpro_bp_get_level_options( -1 ), (array) $level_options );
 
+									$access_note = '';
 									switch ( (int) $level_options['pmpro_bp_restrictions'] ) {
 										case PMPROBP_USE_NON_MEMBER_SETTINGS:
-											$access_label = __( 'Uses non-member user settings', 'pmpro-buddypress' );
+											$access_label     = __( 'Non-member Settings', 'pmpro-buddypress' );
+											$access_tag_class = 'info';
 											break;
 										case PMPROBP_GIVE_ALL_ACCESS:
-											$access_label = __( 'All of BuddyPress unlocked', 'pmpro-buddypress' );
+											$access_label     = __( 'Unlocked', 'pmpro-buddypress' );
+											$access_tag_class = 'success';
 											break;
 										case PMPROBP_SPECIFIC_FEATURES:
 											$feature_keys = array( 'pmpro_bp_group_creation', 'pmpro_bp_group_single_viewing', 'pmpro_bp_groups_page_viewing', 'pmpro_bp_groups_join', 'pmpro_bp_private_messaging', 'pmpro_bp_public_messaging', 'pmpro_bp_send_friend_request', 'pmpro_bp_member_directory' );
@@ -185,12 +188,15 @@ function pmpro_bp_buddpress_admin_page() {
 													$enabled++;
 												}
 											}
+											$access_label     = __( 'Partial Access', 'pmpro-buddypress' );
+											$access_tag_class = 'alert';
 											// translators: %1$d is the number of unlocked features, %2$d is the total number of features.
-											$access_label = sprintf( __( 'Partial access (%1$d of %2$d features unlocked)', 'pmpro-buddypress' ), $enabled, count( $feature_keys ) );
+											$access_note      = sprintf( __( '%1$d of %2$d features unlocked', 'pmpro-buddypress' ), $enabled, count( $feature_keys ) );
 											break;
 										case PMPROBP_LOCK_ALL_ACCESS:
 										default:
-											$access_label = __( 'All of BuddyPress locked', 'pmpro-buddypress' );
+											$access_label     = __( 'Locked', 'pmpro-buddypress' );
+											$access_tag_class = 'error';
 											break;
 									}
 
@@ -213,7 +219,12 @@ function pmpro_bp_buddpress_admin_page() {
 								?>
 								<tr>
 									<td><a href="<?php echo esc_url( $level_edit_url ); ?>" target="_blank"><?php echo esc_html( $pmpro_bp_level->name ); ?></a></td>
-									<td><?php echo esc_html( $access_label ); ?></td>
+									<td>
+										<span class="pmpro_tag pmpro_tag-<?php echo esc_attr( $access_tag_class ); ?>"><?php echo esc_html( $access_label ); ?></span>
+										<?php if ( ! empty( $access_note ) ) { ?>
+											<p class="description"><?php echo esc_html( $access_note ); ?></p>
+										<?php } ?>
+									</td>
 									<td><?php echo ! empty( $member_type_names ) ? esc_html( implode( ', ', $member_type_names ) ) : '&#8212;'; ?></td>
 									<td><?php echo ! empty( $group_names ) ? esc_html( implode( ', ', $group_names ) ) : '&#8212;'; ?></td>
 									<td><a href="<?php echo esc_url( $level_edit_url ); ?>" target="_blank"><?php esc_html_e( 'Edit Level', 'pmpro-buddypress' ); ?></a></td>

--- a/includes/pmpro-buddypress-settings.php
+++ b/includes/pmpro-buddypress-settings.php
@@ -194,16 +194,17 @@ function pmpro_bp_buddpress_admin_page() {
 											break;
 									}
 
-									// Member type names for this level.
+									// Member type names for this level. The saved option may be false or
+									// contain empty entries when nothing is selected, so filter those out.
 									$member_type_names = array();
-									foreach ( (array) $level_options['pmpro_bp_member_types'] as $member_type ) {
+									foreach ( array_filter( (array) $level_options['pmpro_bp_member_types'] ) as $member_type ) {
 										$member_type_object  = function_exists( 'bp_get_member_type_object' ) ? bp_get_member_type_object( $member_type ) : null;
 										$member_type_names[] = ! empty( $member_type_object->labels['singular_name'] ) ? $member_type_object->labels['singular_name'] : $member_type;
 									}
 
-									// Group names this level is automatically added to.
+									// Group names this level is automatically added to (same false/empty handling).
 									$group_names = array();
-									foreach ( (array) $level_options['pmpro_bp_group_automatic_add'] as $group_id ) {
+									foreach ( array_filter( (array) $level_options['pmpro_bp_group_automatic_add'] ) as $group_id ) {
 										$group         = function_exists( 'groups_get_group' ) ? groups_get_group( $group_id ) : null;
 										$group_names[] = ! empty( $group->name ) ? $group->name : '#' . (int) $group_id;
 									}

--- a/includes/profiles.php
+++ b/includes/profiles.php
@@ -18,16 +18,15 @@ function pmpro_bp_update_user_meta( $meta_id, $user_id, $meta_key, $meta_value )
 		return;
 	}
 
-	foreach( $pmpro_user_fields as $field_location )
-	{
-		foreach( $field_location as $rh_field )
-		{
-			if( $rh_field->meta_key == $meta_key && !empty( $rh_field->buddypress ) ) {
+	foreach( $pmpro_user_fields as $field_location ) {
+		foreach( $field_location as $user_field ) {
+			if( $user_field->meta_key == $meta_key && !empty( $user_field->buddypress ) ) {
 				//switch for type
-				
-				$x_field = xprofile_get_field_id_from_name( $rh_field->buddypress );
 
-				if( !empty( $x_field ) ) {
+				// ->buddypress may be an Xprofile field ID (from the mapping screen) or a name (legacy).
+				$x_field = pmpro_bp_resolve_xprofile_field_id( $user_field->buddypress );
+
+				if( ! empty( $x_field ) ) {
 					// Get the current visibility for the xprofile field. If not set, this will get the default.
 					$x_field_visibility = xprofile_get_field_visibility_level( $x_field, $user_id );
 
@@ -66,7 +65,7 @@ function pmpro_bp_xprofile_updated_profile( $user_id, $posted_field_ids, $errors
 			
 			foreach( $pmpro_user_fields as $field_location ) {
 				foreach( $field_location as $rh_field ) {
-					if( !empty( $rh_field->buddypress ) && $rh_field->buddypress == $xprofile_field->name ) {
+					if( !empty( $rh_field->buddypress ) && pmpro_bp_resolve_xprofile_field_id( $rh_field->buddypress ) == $xprofile_field_id ) {
 						//switch for type?
 						update_user_meta( $user_id, $rh_field->meta_key, $new_values[$xprofile_field_id]['value'] );
 					}

--- a/includes/xprofile-mapping.php
+++ b/includes/xprofile-mapping.php
@@ -166,9 +166,8 @@ add_action( 'init', 'pmpro_bp_apply_xprofile_field_map', 20 );
  * Save the submitted Xprofile field map.
  *
  * Called from the main PMPro BuddyPress settings handler when its form is
- * submitted, so the map is persisted alongside the other settings. Bails
- * quietly (rather than dying) if the section nonce is missing or invalid, so a
- * failed check here doesn't block the rest of the shared form from saving.
+ * submitted, so the map is persisted alongside the other settings. The caller
+ * is responsible for capability and nonce checks on the request.
  *
  * @since TBD
  */
@@ -177,13 +176,15 @@ function pmpro_bp_save_xprofile_field_map() {
 		return;
 	}
 
-	$nonce = isset( $_POST['pmpro_bp_xprofile_mapping_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['pmpro_bp_xprofile_mapping_nonce'] ) ) : '';
-	if ( ! wp_verify_nonce( $nonce, 'pmpro_bp_xprofile_mapping' ) ) {
-		return;
-	}
-
 	$user_fields     = pmpro_bp_get_all_user_fields();
 	$xprofile_fields = pmpro_bp_get_xprofile_fields();
+
+	// If either side of the mapping is unavailable (e.g. the Xprofile component
+	// is disabled or no user fields are registered right now), leave the saved
+	// map alone rather than wiping it.
+	if ( empty( $user_fields ) || empty( $xprofile_fields ) ) {
+		return;
+	}
 
 	$submitted = isset( $_POST['pmpro_bp_xprofile_map'] ) ? (array) $_POST['pmpro_bp_xprofile_map'] : array();
 
@@ -213,12 +214,12 @@ function pmpro_bp_save_xprofile_field_map() {
 }
 
 /**
- * Render the Xprofile Field Mapping section.
+ * Render the Xprofile Field Mapping section content.
  *
- * Outputs the section heading, mapping table and helper JS. Designed to be
- * called from inside the main PMPro BuddyPress settings <form>, so it has no
- * <form> tag or submit button of its own — the form's "Save All Settings"
- * button submits the map, and pmpro_bp_save_xprofile_field_map() saves it.
+ * Outputs the mapping table and helper JS. Designed to be called from inside
+ * the main PMPro BuddyPress settings <form>, so it has no <form> tag, nonce,
+ * heading, or submit button of its own — the settings page provides those and
+ * pmpro_bp_save_xprofile_field_map() saves the map on submit.
  *
  * @since TBD
  */
@@ -227,10 +228,7 @@ function pmpro_bp_render_xprofile_mapping_section() {
 	$xprofile_fields = pmpro_bp_get_xprofile_fields();
 	$map             = pmpro_bp_get_xprofile_field_map();
 	?>
-	<h3><?php esc_html_e( 'Xprofile Field Mapping', 'pmpro-buddypress' ); ?></h3>
 	<p><?php esc_html_e( 'Map your BuddyPress or BuddyBoss Xprofile fields to Paid Memberships Pro User Fields. Each Xprofile field can be mapped to one User Field, and mapped fields will stay in sync in both directions.', 'pmpro-buddypress' ); ?></p>
-
-	<?php wp_nonce_field( 'pmpro_bp_xprofile_mapping', 'pmpro_bp_xprofile_mapping_nonce' ); ?>
 
 	<?php if ( empty( $xprofile_fields ) ) { ?>
 		<div class="notice notice-warning inline"><p><?php esc_html_e( 'No Xprofile fields were found. Make sure BuddyPress or BuddyBoss is active and you have created Profile Fields.', 'pmpro-buddypress' ); ?></p></div>

--- a/includes/xprofile-mapping.php
+++ b/includes/xprofile-mapping.php
@@ -123,6 +123,10 @@ function pmpro_bp_resolve_xprofile_field_id( $buddypress ) {
  *
  * Runs after PMPro loads its settings-based fields (init, priority 1).
  *
+ * A UI mapping always takes precedence over a code-set ->buddypress attribute
+ * for the same meta_key: if a developer has set $field->buddypress in code and a
+ * UI mapping exists for that field's meta_key, the UI mapping overwrites it.
+ *
  * @since TBD
  */
 function pmpro_bp_apply_xprofile_field_map() {
@@ -169,7 +173,11 @@ add_action( 'init', 'pmpro_bp_apply_xprofile_field_map', 20 );
  * @since TBD
  */
 function pmpro_bp_save_xprofile_field_map() {
-	$nonce = isset( $_REQUEST['pmpro_bp_xprofile_mapping_nonce'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['pmpro_bp_xprofile_mapping_nonce'] ) ) : '';
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	$nonce = isset( $_POST['pmpro_bp_xprofile_mapping_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['pmpro_bp_xprofile_mapping_nonce'] ) ) : '';
 	if ( ! wp_verify_nonce( $nonce, 'pmpro_bp_xprofile_mapping' ) ) {
 		return;
 	}

--- a/includes/xprofile-mapping.php
+++ b/includes/xprofile-mapping.php
@@ -55,6 +55,9 @@ function pmpro_bp_get_all_user_fields() {
 /**
  * Get the list of available Xprofile fields for the mapping table.
  *
+ * The primary "Name" field is excluded: BuddyPress already keeps that field
+ * in sync with the WordPress user's display name on its own.
+ *
  * @since TBD
  * @return array Map of xprofile field ID => field name.
  */
@@ -71,12 +74,19 @@ function pmpro_bp_get_xprofile_fields() {
 		return $xprofile_fields;
 	}
 
+	$fullname_field_id = function_exists( 'bp_xprofile_fullname_field_id' ) ? (int) bp_xprofile_fullname_field_id() : 0;
+
 	foreach ( $groups as $group ) {
 		if ( empty( $group->fields ) ) {
 			continue;
 		}
 
 		foreach ( $group->fields as $xprofile_field ) {
+			// Skip the primary "Name" field; BuddyPress syncs it with display_name itself.
+			if ( ! empty( $fullname_field_id ) && (int) $xprofile_field->id === $fullname_field_id ) {
+				continue;
+			}
+
 			// Key on the field ID so the mapping survives a field being renamed.
 			$xprofile_fields[ (int) $xprofile_field->id ] = $xprofile_field->name;
 		}
@@ -228,7 +238,7 @@ function pmpro_bp_render_xprofile_mapping_section() {
 	$xprofile_fields = pmpro_bp_get_xprofile_fields();
 	$map             = pmpro_bp_get_xprofile_field_map();
 	?>
-	<p><?php esc_html_e( 'Map your BuddyPress or BuddyBoss Xprofile fields to Paid Memberships Pro User Fields. Each Xprofile field can be mapped to one User Field, and mapped fields will stay in sync in both directions.', 'pmpro-buddypress' ); ?></p>
+	<p><?php esc_html_e( 'Map BuddyPress or BuddyBoss extended profile fields to user meta fields. Each extended profile field can be mapped to one user field. Fields stay in sync when updated in either location.', 'pmpro-buddypress' ); ?></p>
 
 	<?php if ( empty( $xprofile_fields ) ) { ?>
 		<div class="notice notice-warning inline"><p><?php esc_html_e( 'No Xprofile fields were found. Make sure BuddyPress or BuddyBoss is active and you have created Profile Fields.', 'pmpro-buddypress' ); ?></p></div>

--- a/includes/xprofile-mapping.php
+++ b/includes/xprofile-mapping.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * Settings screen to map BuddyPress/BuddyBoss Xprofile fields to Paid
+ * Memberships Pro User Fields. (1:1 mapping only).
+ * @since TBD
+*/
+
+/**
+ * Get the saved Xprofile field => User Field map.
+ *
+ * @since TBD
+ * @return array Map of xprofile field ID => user field meta_key.
+ */
+function pmpro_bp_get_xprofile_field_map() {
+	$map = get_option( 'pmpro_bp_xprofile_field_map', array() );
+
+	if ( ! is_array( $map ) ) {
+		$map = array();
+	}
+
+	return $map;
+}
+
+/**
+ * Get all registered PMPro user fields, flattened and de-duplicated by meta_key.
+ *
+ * Fields are stored per group/location and the same field can appear in more
+ * than one location, so we collapse to a single entry per meta_key.
+ *
+ * @since TBD
+ * @return PMPro_Field[] Array of field objects keyed by meta_key.
+ */
+function pmpro_bp_get_all_user_fields() {
+	$fields = array();
+
+	if ( ! class_exists( 'PMPro_Field_Group' ) ) {
+		return $fields;
+	}
+
+	foreach ( PMPro_Field_Group::get_all() as $group ) {
+		foreach ( $group->get_fields() as $user_field ) {
+			if ( empty( $user_field->meta_key ) ) {
+				continue;
+			}
+
+			if ( ! isset( $fields[ $user_field->meta_key ] ) ) {
+				$fields[ $user_field->meta_key ] = $user_field;
+			}
+		}
+	}
+
+	return $fields;
+}
+
+/**
+ * Get the list of available Xprofile fields for the mapping table.
+ *
+ * @since TBD
+ * @return array Map of xprofile field ID => field name.
+ */
+function pmpro_bp_get_xprofile_fields() {
+	$xprofile_fields = array();
+
+	if ( ! function_exists( 'bp_xprofile_get_groups' ) ) {
+		return $xprofile_fields;
+	}
+
+	$groups = bp_xprofile_get_groups( array( 'fetch_fields' => true ) );
+
+	if ( empty( $groups ) ) {
+		return $xprofile_fields;
+	}
+
+	foreach ( $groups as $group ) {
+		if ( empty( $group->fields ) ) {
+			continue;
+		}
+
+		foreach ( $group->fields as $xprofile_field ) {
+			// Key on the field ID so the mapping survives a field being renamed.
+			$xprofile_fields[ (int) $xprofile_field->id ] = $xprofile_field->name;
+		}
+	}
+
+	return $xprofile_fields;
+}
+
+/**
+ * Resolve a stored ->buddypress value to an Xprofile field ID.
+ *
+ * Accepts either an Xprofile field ID (the format saved by this settings
+ * screen) or an Xprofile field name (the legacy format that code-based
+ * mappings may still use), so both keep working.
+ *
+ * @since TBD
+ * @param int|string $buddypress The ->buddypress attribute value.
+ * @return int The Xprofile field ID, or 0 if it can't be resolved.
+ */
+function pmpro_bp_resolve_xprofile_field_id( $buddypress ) {
+	if ( empty( $buddypress ) ) {
+		return 0;
+	}
+
+	// Numeric value: treat as a field ID directly.
+	if ( is_numeric( $buddypress ) ) {
+		return (int) $buddypress;
+	}
+
+	// Otherwise treat it as a legacy field name.
+	if ( function_exists( 'xprofile_get_field_id_from_name' ) ) {
+		return (int) xprofile_get_field_id_from_name( $buddypress );
+	}
+
+	return 0;
+}
+
+/**
+ * Apply the saved map to the registered user fields object.
+ *
+ * Loops through the registered user fields and stamps the ->buddypress attribute
+ * onto each field that has a mapping. profiles.php then handles the actual
+ * two-way sync based on that attribute.
+ *
+ * Runs after PMPro loads its settings-based fields (init, priority 1).
+ *
+ * @since TBD
+ */
+function pmpro_bp_apply_xprofile_field_map() {
+	if ( ! class_exists( 'PMPro_Field_Group' ) ) {
+		return;
+	}
+
+	$map = pmpro_bp_get_xprofile_field_map();
+
+	if ( empty( $map ) ) {
+		return;
+	}
+
+	// The map is keyed by Xprofile field ID; flip it to meta_key => xprofile_id
+	// so we can look up each user field as we loop.
+	$xprofile_id_by_meta_key = array();
+	foreach ( $map as $xprofile_id => $meta_key ) {
+		$xprofile_id_by_meta_key[ $meta_key ] = (int) $xprofile_id;
+	}
+
+	foreach ( PMPro_Field_Group::get_all() as $group ) {
+		foreach ( $group->get_fields() as $user_field ) {
+			if ( empty( $user_field->meta_key ) ) {
+				continue;
+			}
+
+			if ( ! empty( $xprofile_id_by_meta_key[ $user_field->meta_key ] ) ) {
+				// Stamp the Xprofile field ID onto the field object so profiles.php picks it up.
+				$user_field->buddypress = $xprofile_id_by_meta_key[ $user_field->meta_key ];
+			}
+		}
+	}
+}
+add_action( 'init', 'pmpro_bp_apply_xprofile_field_map', 20 );
+
+/**
+ * Save the submitted Xprofile field map.
+ *
+ * Called from the main PMPro BuddyPress settings handler when its form is
+ * submitted, so the map is persisted alongside the other settings. Bails
+ * quietly (rather than dying) if the section nonce is missing or invalid, so a
+ * failed check here doesn't block the rest of the shared form from saving.
+ *
+ * @since TBD
+ */
+function pmpro_bp_save_xprofile_field_map() {
+	$nonce = isset( $_REQUEST['pmpro_bp_xprofile_mapping_nonce'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['pmpro_bp_xprofile_mapping_nonce'] ) ) : '';
+	if ( ! wp_verify_nonce( $nonce, 'pmpro_bp_xprofile_mapping' ) ) {
+		return;
+	}
+
+	$user_fields     = pmpro_bp_get_all_user_fields();
+	$xprofile_fields = pmpro_bp_get_xprofile_fields();
+
+	$submitted = isset( $_POST['pmpro_bp_xprofile_map'] ) ? (array) $_POST['pmpro_bp_xprofile_map'] : array();
+
+	$new_map        = array();
+	$used_meta_keys = array();
+
+	// Submitted as xprofile_field_id => user_field_meta_key.
+	foreach ( $submitted as $xprofile_id => $meta_key ) {
+		$xprofile_id = (int) $xprofile_id;
+		$meta_key    = sanitize_text_field( wp_unslash( $meta_key ) );
+
+		// Skip blanks and anything we don't recognize.
+		if ( empty( $meta_key ) || ! isset( $xprofile_fields[ $xprofile_id ] ) || ! isset( $user_fields[ $meta_key ] ) ) {
+			continue;
+		}
+
+		// Enforce a strict one-to-one mapping: a user field can only be claimed once.
+		if ( isset( $used_meta_keys[ $meta_key ] ) ) {
+			continue;
+		}
+
+		$new_map[ $xprofile_id ]    = $meta_key;
+		$used_meta_keys[ $meta_key ] = true;
+	}
+
+	update_option( 'pmpro_bp_xprofile_field_map', $new_map, 'no' );
+}
+
+/**
+ * Render the Xprofile Field Mapping section.
+ *
+ * Outputs the section heading, mapping table and helper JS. Designed to be
+ * called from inside the main PMPro BuddyPress settings <form>, so it has no
+ * <form> tag or submit button of its own — the form's "Save All Settings"
+ * button submits the map, and pmpro_bp_save_xprofile_field_map() saves it.
+ *
+ * @since TBD
+ */
+function pmpro_bp_render_xprofile_mapping_section() {
+	$user_fields     = pmpro_bp_get_all_user_fields();
+	$xprofile_fields = pmpro_bp_get_xprofile_fields();
+	$map             = pmpro_bp_get_xprofile_field_map();
+	?>
+	<h3><?php esc_html_e( 'Xprofile Field Mapping', 'pmpro-buddypress' ); ?></h3>
+	<p><?php esc_html_e( 'Map your BuddyPress or BuddyBoss Xprofile fields to Paid Memberships Pro User Fields. Each Xprofile field can be mapped to one User Field, and mapped fields will stay in sync in both directions.', 'pmpro-buddypress' ); ?></p>
+
+	<?php wp_nonce_field( 'pmpro_bp_xprofile_mapping', 'pmpro_bp_xprofile_mapping_nonce' ); ?>
+
+	<?php if ( empty( $xprofile_fields ) ) { ?>
+		<div class="notice notice-warning inline"><p><?php esc_html_e( 'No Xprofile fields were found. Make sure BuddyPress or BuddyBoss is active and you have created Profile Fields.', 'pmpro-buddypress' ); ?></p></div>
+	<?php } elseif ( empty( $user_fields ) ) { ?>
+		<div class="notice notice-warning inline"><p>
+			<?php
+			printf(
+				// translators: %s is a link to the PMPro User Fields settings screen.
+				esc_html__( 'No Paid Memberships Pro User Fields were found. %s to add some first.', 'pmpro-buddypress' ),
+				'<a href="' . esc_url( admin_url( 'admin.php?page=pmpro-userfields' ) ) . '">' . esc_html__( 'Edit User Fields', 'pmpro-buddypress' ) . '</a>'
+			);
+			?>
+		</p></div>
+	<?php } else { ?>
+		<table class="widefat striped">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Xprofile Field', 'pmpro-buddypress' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'User Field', 'pmpro-buddypress' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $xprofile_fields as $xprofile_id => $xprofile_name ) { ?>
+					<?php $selected_meta_key = isset( $map[ $xprofile_id ] ) ? $map[ $xprofile_id ] : ''; ?>
+					<tr<?php echo empty( $selected_meta_key ) ? ' class="pmpro_gray"' : ''; ?>>
+						<td><strong><?php echo esc_html( $xprofile_name ); ?></strong></td>
+						<td>
+							<select class="pmpro-bp-xprofile-map-select" name="pmpro_bp_xprofile_map[<?php echo esc_attr( $xprofile_id ); ?>]">
+								<option value=""><?php esc_html_e( '— Not mapped —', 'pmpro-buddypress' ); ?></option>
+								<?php foreach ( $user_fields as $meta_key => $user_field ) { ?>
+									<option value="<?php echo esc_attr( $meta_key ); ?>" <?php selected( $selected_meta_key, $meta_key ); ?>>
+										<?php echo esc_html( ! empty( $user_field->label ) ? $user_field->label : $meta_key ); ?>
+									</option>
+								<?php } ?>
+							</select>
+						</td>
+					</tr>
+				<?php } ?>
+			</tbody>
+		</table>
+
+		<script>
+		( function() {
+			var selects = document.querySelectorAll( '.pmpro-bp-xprofile-map-select' );
+			if ( ! selects.length ) {
+				return;
+			}
+
+			var inUseSuffix = <?php echo wp_json_encode( ' ' . __( '(in use)', 'pmpro-buddypress' ) ); ?>;
+
+			// Remember each option's original label so we can toggle the suffix.
+			selects.forEach( function( select ) {
+				Array.prototype.forEach.call( select.options, function( option ) {
+					option.setAttribute( 'data-base-label', option.textContent.trim() );
+				} );
+			} );
+
+			// Disable any user field already chosen in a different dropdown (strict 1:1).
+			function refresh() {
+				var chosen = {};
+				selects.forEach( function( select ) {
+					if ( select.value ) {
+						chosen[ select.value ] = select;
+					}
+				} );
+
+				selects.forEach( function( select ) {
+					Array.prototype.forEach.call( select.options, function( option ) {
+						if ( '' === option.value ) {
+							return;
+						}
+						var owner = chosen[ option.value ];
+						var taken = owner && owner !== select;
+						option.disabled = !! taken;
+						option.textContent = option.getAttribute( 'data-base-label' ) + ( taken ? inUseSuffix : '' );
+					} );
+				} );
+			}
+
+			selects.forEach( function( select ) {
+				select.addEventListener( 'change', refresh );
+			} );
+
+			refresh();
+		}() );
+		</script>
+	<?php } ?>
+	<?php
+}

--- a/pmpro-buddypress.php
+++ b/pmpro-buddypress.php
@@ -39,6 +39,7 @@ require_once( PMPROBP_DIR . '/includes/directory.php' );
 require_once( PMPROBP_DIR . '/includes/groups.php' );
 require_once( PMPROBP_DIR . '/includes/member-types.php' );
 require_once( PMPROBP_DIR . '/includes/profiles.php' );
+require_once( PMPROBP_DIR . '/includes/xprofile-mapping.php' );
 require_once( PMPROBP_DIR . '/includes/registration.php' );
 require_once( PMPROBP_DIR . '/includes/restrictions.php' );
 


### PR DESCRIPTION
* ENHANCEMENT: Add support for easier XProfile field mapping to User Fields.

This allows mapping of XProfile Fields to User Fields and adds `->buddypress` attribute to the User Fields object whenever getting the fields (if there is a mapping selection). This was initially going to be added to it's own page, but it felt okay to squeeze it into the BuddyPress settings which is a step towards more level settings overview.

This creates a 1:1 mapping between User Fields and PMPro. TBH we could do away with that logic if we feel sites need multiple mapping (I believe that would still work but could cause confusion to some people if they incorrectly map things and it's best to 1:1 map to prevent user errors). This also loads a small-ish script to disable the User Field option once selected (on dropdown change or page load/preloaded selections).

**No User Fields Found**
<img width="2370" height="559" alt="Screenshot 2026-06-03 at 15 28 13" src="https://github.com/user-attachments/assets/c5833ea1-14ad-4d6e-9d90-2bfe5352443d" />

**With User Fields Available**
<img width="2560" height="2004" alt="buddypress" src="https://github.com/user-attachments/assets/2594ae4c-10bc-4d37-9364-10abea0607aa" />

Resolves: https://github.com/strangerstudios/pmpro-buddypress/issues/127