### PR TITLE
Add BP Docs and BuddyBoss Document restrictions

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -18,6 +18,8 @@ function pmpro_bp_get_level_options( $level_id ) {
 		'pmpro_bp_public_messaging'         => 0,
 		'pmpro_bp_send_friend_request'      => 0,
 		'pmpro_bp_member_directory'         => 0,
+		'pmpro_bp_docs_view'                => 0,
+		'pmpro_bp_docs_upload'              => 0,
 		'pmpro_bp_group_automatic_add'      => array(),
 		'pmpro_bp_group_can_request_invite' => array(),
 		'pmpro_bp_member_types'             => array(),
@@ -45,6 +47,8 @@ function pmpro_bp_get_level_options( $level_id ) {
 			$options['pmpro_bp_public_messaging'] = $non_member_user_options['pmpro_bp_public_messaging'];
 			$options['pmpro_bp_send_friend_request'] = $non_member_user_options['pmpro_bp_send_friend_request'];
 			$options['pmpro_bp_member_directory'] = $non_member_user_options['pmpro_bp_member_directory'];
+			$options['pmpro_bp_docs_view'] = $non_member_user_options['pmpro_bp_docs_view'];
+			$options['pmpro_bp_docs_upload'] = $non_member_user_options['pmpro_bp_docs_upload'];
 		}
 	}
 
@@ -113,6 +117,8 @@ function pmpro_bp_get_user_options( $user_id = null ) {
 			$pmpro_bp_all_options['pmpro_bp_public_messaging'] = max( $pmpro_bp_all_options['pmpro_bp_public_messaging'], $pmpro_bp_options['pmpro_bp_public_messaging'] );
 			$pmpro_bp_all_options['pmpro_bp_send_friend_request'] = max( $pmpro_bp_all_options['pmpro_bp_send_friend_request'], $pmpro_bp_options['pmpro_bp_send_friend_request'] );
 			$pmpro_bp_all_options['pmpro_bp_member_directory'] = max( $pmpro_bp_all_options['pmpro_bp_member_directory'], $pmpro_bp_options['pmpro_bp_member_directory'] );
+			$pmpro_bp_all_options['pmpro_bp_docs_view'] = max( $pmpro_bp_all_options['pmpro_bp_docs_view'], $pmpro_bp_options['pmpro_bp_docs_view'] );
+			$pmpro_bp_all_options['pmpro_bp_docs_upload'] = max( $pmpro_bp_all_options['pmpro_bp_docs_upload'], $pmpro_bp_options['pmpro_bp_docs_upload'] );
 
 			// groups to add
 			$pmpro_bp_all_options['pmpro_bp_group_automatic_add'] = array_unique( array_merge( (array) $pmpro_bp_all_options['pmpro_bp_group_automatic_add'], (array) $pmpro_bp_options['pmpro_bp_group_automatic_add'] ) );

--- a/includes/documents.php
+++ b/includes/documents.php
@@ -3,9 +3,6 @@
 	Code to restrict BuddyBoss Platform Documents and BP Docs based on membership level.
 */
 
-// -------------------------------------------------------------------------
-// BuddyBoss Platform Documents
-// -------------------------------------------------------------------------
 
 /**
  * Block the BuddyBoss AJAX file-upload step for documents when upload is restricted.
@@ -52,7 +49,9 @@ function pmpro_bp_restrict_bb_document_viewing() {
 		pmpro_bp_redirect_to_access_required_page();
 	}
 }
-add_action( 'template_redirect', 'pmpro_bp_restrict_bb_document_viewing' );
+if ( function_exists( 'bb_user_can_create_document' ) ) {
+	add_action( 'template_redirect', 'pmpro_bp_restrict_bb_document_viewing' );
+}
 
 /**
  * Remove the Documents nav item from member profiles when viewing is restricted.
@@ -66,7 +65,9 @@ function pmpro_bp_remove_document_nav() {
 		bp_core_remove_nav_item( 'document' );
 	}
 }
-add_action( 'bp_setup_nav', 'pmpro_bp_remove_document_nav', 100 );
+if ( function_exists( 'bb_user_can_create_document' ) ) {
+	add_action( 'bp_setup_nav', 'pmpro_bp_remove_document_nav', 100 );
+}
 
 // -------------------------------------------------------------------------
 // BP Docs
@@ -113,4 +114,6 @@ function pmpro_bp_restrict_bp_docs_viewing() {
 		pmpro_bp_redirect_to_access_required_page();
 	}
 }
-add_action( 'template_redirect', 'pmpro_bp_restrict_bp_docs_viewing' );
+if ( function_exists( 'bp_docs_is_docs_component' ) ) {
+	add_action( 'template_redirect', 'pmpro_bp_restrict_bp_docs_viewing' );
+}

--- a/includes/documents.php
+++ b/includes/documents.php
@@ -1,0 +1,116 @@
+<?php
+/*
+	Code to restrict BuddyBoss Platform Documents and BP Docs based on membership level.
+*/
+
+// -------------------------------------------------------------------------
+// BuddyBoss Platform Documents
+// -------------------------------------------------------------------------
+
+/**
+ * Block the BuddyBoss AJAX file-upload step for documents when upload is restricted.
+ *
+ * BuddyBoss registers wp_ajax_document_document_upload in admin_init at priority 10.
+ * Running at priority 1 ensures we exit before their callback fires.
+ * This covers both profile and group upload contexts.
+ */
+function pmpro_bp_ajax_document_upload_check() {
+	if ( ! pmpro_bp_user_can( 'docs_upload' ) ) {
+		wp_send_json_error(
+			array( 'feedback' => __( 'You do not have permission to upload documents.', 'pmpro-buddypress' ) ),
+			403
+		);
+	}
+}
+add_action( 'wp_ajax_document_document_upload', 'pmpro_bp_ajax_document_upload_check', 1 );
+
+/**
+ * Block the BuddyBoss AJAX document-save step when upload is restricted.
+ *
+ * The save handler calls groups_can_user_manage_document() directly for group uploads,
+ * bypassing bb_user_can_create_document, so we must intercept at the AJAX action level.
+ */
+function pmpro_bp_ajax_document_save_check() {
+	if ( ! pmpro_bp_user_can( 'docs_upload' ) ) {
+		wp_send_json_error(
+			array( 'feedback' => __( 'You do not have permission to upload documents.', 'pmpro-buddypress' ) ),
+			403
+		);
+	}
+}
+add_action( 'wp_ajax_document_document_save', 'pmpro_bp_ajax_document_save_check', 1 );
+
+/**
+ * Redirect away from the BuddyBoss Documents component page when viewing is restricted.
+ */
+function pmpro_bp_restrict_bb_document_viewing() {
+	if ( ! function_exists( 'bp_is_current_component' ) ) {
+		return;
+	}
+
+	if ( bp_is_current_component( 'document' ) && ! pmpro_bp_user_can( 'docs_view' ) ) {
+		pmpro_bp_redirect_to_access_required_page();
+	}
+}
+add_action( 'template_redirect', 'pmpro_bp_restrict_bb_document_viewing' );
+
+/**
+ * Remove the Documents nav item from member profiles when viewing is restricted.
+ */
+function pmpro_bp_remove_document_nav() {
+	if ( ! function_exists( 'bp_core_remove_nav_item' ) ) {
+		return;
+	}
+
+	if ( ! pmpro_bp_user_can( 'docs_view' ) ) {
+		bp_core_remove_nav_item( 'document' );
+	}
+}
+add_action( 'bp_setup_nav', 'pmpro_bp_remove_document_nav', 100 );
+
+// -------------------------------------------------------------------------
+// BP Docs
+// -------------------------------------------------------------------------
+
+/**
+ * Prevent users from creating BP Docs when restricted.
+ * Hooks into BP Docs' own "can create in context" filter.
+ */
+function pmpro_bp_bp_docs_user_can_create( $can_create ) {
+	if ( $can_create && ! pmpro_bp_user_can( 'docs_upload' ) ) {
+		$can_create = false;
+	}
+	return $can_create;
+}
+add_filter( 'bp_docs_current_user_can_create_in_context', 'pmpro_bp_bp_docs_user_can_create' );
+
+/**
+ * Restrict per-doc read access for users who don't have view permission.
+ * This fires on the bp_docs_user_can filter for 'read' and 'read_comments' actions.
+ */
+function pmpro_bp_bp_docs_user_can( $user_can, $action, $user_id, $doc_id ) {
+	if ( in_array( $action, array( 'read', 'read_comments' ), true ) && ! pmpro_bp_user_can( 'docs_view', $user_id ) ) {
+		$user_can = false;
+	}
+
+	if ( 'create' === $action && ! pmpro_bp_user_can( 'docs_upload', $user_id ) ) {
+		$user_can = false;
+	}
+
+	return $user_can;
+}
+add_filter( 'bp_docs_user_can', 'pmpro_bp_bp_docs_user_can', 10, 4 );
+
+/**
+ * Redirect away from BP Docs pages when view access is restricted.
+ */
+function pmpro_bp_restrict_bp_docs_viewing() {
+	if ( ! function_exists( 'bp_docs_is_docs_component' ) ) {
+		return;
+	}
+
+	if ( bp_docs_is_docs_component() && ! pmpro_bp_user_can( 'docs_view' ) ) {
+		pmpro_bp_redirect_to_access_required_page();
+	}
+}
+add_action( 'template_redirect', 'pmpro_bp_restrict_bp_docs_viewing' );

--- a/includes/membership-level-settings.php
+++ b/includes/membership-level-settings.php
@@ -172,6 +172,8 @@ function pmpro_bp_pmpro_save_membership_level($level_id)
 	$pmpro_bp_private_messaging = intval( $_REQUEST['pmpro_bp_private_messaging'] );
 	$pmpro_bp_send_friend_request = intval( $_REQUEST['pmpro_bp_send_friend_request'] );
 	$pmpro_bp_member_directory = intval( $_REQUEST['pmpro_bp_member_directory'] );
+	$pmpro_bp_docs_view = isset( $_REQUEST['pmpro_bp_docs_view'] ) ? intval( $_REQUEST['pmpro_bp_docs_view'] ) : 0;
+	$pmpro_bp_docs_upload = isset( $_REQUEST['pmpro_bp_docs_upload'] ) ? intval( $_REQUEST['pmpro_bp_docs_upload'] ) : 0;
 	
 	if( isset( $_REQUEST['pmpro_bp_group_automatic_add'] ) ) {
 		$pmpro_bp_group_automatic_add = array_map( 'sanitize_text_field', $_REQUEST['pmpro_bp_group_automatic_add'] );
@@ -196,11 +198,13 @@ function pmpro_bp_pmpro_save_membership_level($level_id)
 		'pmpro_bp_group_creation'			=> $can_create_groups,
 		'pmpro_bp_group_single_viewing'		=> $can_view_single_group,
 		'pmpro_bp_groups_page_viewing'		=> $can_view_groups_page,
-		'pmpro_bp_groups_join'				=> $can_join_groups,		
+		'pmpro_bp_groups_join'				=> $can_join_groups,
 		'pmpro_bp_private_messaging'		=> $pmpro_bp_private_messaging,
 		'pmpro_bp_public_messaging'			=> $pmpro_bp_public_messaging,
 		'pmpro_bp_send_friend_request'		=> $pmpro_bp_send_friend_request,
 		'pmpro_bp_member_directory'			=> $pmpro_bp_member_directory,
+		'pmpro_bp_docs_view'				=> $pmpro_bp_docs_view,
+		'pmpro_bp_docs_upload'				=> $pmpro_bp_docs_upload,
 		'pmpro_bp_group_automatic_add'		=> $pmpro_bp_group_automatic_add,
 		'pmpro_bp_group_can_request_invite'	=> $pmpro_bp_group_can_request_invite,
 		'pmpro_bp_member_types'				=> $pmpro_bp_member_types);
@@ -228,8 +232,11 @@ function pmpro_bp_restriction_settings_form( $level_id = NULL) {
 	$pmpro_bp_restrictions			= $pmpro_bp_options['pmpro_bp_restrictions'];
 	$pmpro_bp_private_messaging		= $pmpro_bp_options['pmpro_bp_private_messaging'];
 	$pmpro_bp_public_messaging		= $pmpro_bp_options['pmpro_bp_public_messaging'];
-	$pmpro_bp_send_friend_request		= $pmpro_bp_options['pmpro_bp_send_friend_request'];		
+	$pmpro_bp_send_friend_request		= $pmpro_bp_options['pmpro_bp_send_friend_request'];
 	$pmpro_bp_member_directory		= $pmpro_bp_options['pmpro_bp_member_directory'];
+	$pmpro_bp_docs_view			= $pmpro_bp_options['pmpro_bp_docs_view'];
+	$pmpro_bp_docs_upload			= $pmpro_bp_options['pmpro_bp_docs_upload'];
+	$pmpro_bp_has_docs			= function_exists( 'bb_user_can_create_document' ) || function_exists( 'bp_docs_user_can' );
 	?>
 	<?php if( $level_id <> 0 ) { ?>
 		<hr />
@@ -446,6 +453,51 @@ function pmpro_bp_restriction_settings_form( $level_id = NULL) {
 				</p>
 				</td>
 			</tr>
+
+			<?php if ( $pmpro_bp_has_docs ) { ?>
+
+			<?php //viewing docs ?>
+			<tr>
+			<th scope="row" valign="top"><label for="pmpro_bp_docs_view"><?php _e('View Documents', 'pmpro-buddypress');?>:</label></th>
+			<td>
+				<select name="pmpro_bp_docs_view" id="pmpro_bp_docs_view">
+						<option value='0' <?php if ( $pmpro_bp_docs_view == 0 ) echo 'selected'; ?>><?php _e('No', 'pmpro-buddypress');?></option>
+						<option value='1' <?php if ( $pmpro_bp_docs_view == 1 ) echo 'selected'; ?>><?php _e('Yes', 'pmpro-buddypress');?></option>
+				</select>
+				<p class="description">
+				<?php
+					if ( $level_id <> 0 ) {
+						_e( 'Can members of this level view documents and folders?', 'pmpro-buddypress' );
+					} else {
+						_e( 'Can non-member users view documents and folders?', 'pmpro-buddypress' );
+					}
+				?>
+				</p>
+			</td>
+			</tr>
+
+			<?php //uploading docs ?>
+			<tr>
+			<th scope="row" valign="top"><label for="pmpro_bp_docs_upload"><?php _e('Upload Documents', 'pmpro-buddypress');?>:</label></th>
+			<td>
+				<select name="pmpro_bp_docs_upload" id="pmpro_bp_docs_upload">
+						<option value='0' <?php if ( $pmpro_bp_docs_upload == 0 ) echo 'selected'; ?>><?php _e('No', 'pmpro-buddypress');?></option>
+						<option value='1' <?php if ( $pmpro_bp_docs_upload == 1 ) echo 'selected'; ?>><?php _e('Yes', 'pmpro-buddypress');?></option>
+				</select>
+				<p class="description">
+				<?php
+					if ( $level_id <> 0 ) {
+						_e( 'Can members of this level upload or create documents?', 'pmpro-buddypress' );
+					} else {
+						_e( 'Can non-member users upload or create documents?', 'pmpro-buddypress' );
+					}
+				?>
+				</p>
+			</td>
+			</tr>
+
+			<?php } // end if has docs ?>
+
 	</tbody>
 	</table>
 	<script>

--- a/includes/membership-level-settings.php
+++ b/includes/membership-level-settings.php
@@ -174,7 +174,7 @@ function pmpro_bp_pmpro_save_membership_level($level_id)
 	$pmpro_bp_member_directory = intval( $_REQUEST['pmpro_bp_member_directory'] );
 	$pmpro_bp_docs_view = isset( $_REQUEST['pmpro_bp_docs_view'] ) ? intval( $_REQUEST['pmpro_bp_docs_view'] ) : 0;
 	$pmpro_bp_docs_upload = isset( $_REQUEST['pmpro_bp_docs_upload'] ) ? intval( $_REQUEST['pmpro_bp_docs_upload'] ) : 0;
-	
+
 	if( isset( $_REQUEST['pmpro_bp_group_automatic_add'] ) ) {
 		$pmpro_bp_group_automatic_add = array_map( 'sanitize_text_field', $_REQUEST['pmpro_bp_group_automatic_add'] );
 	} else {
@@ -198,7 +198,7 @@ function pmpro_bp_pmpro_save_membership_level($level_id)
 		'pmpro_bp_group_creation'			=> $can_create_groups,
 		'pmpro_bp_group_single_viewing'		=> $can_view_single_group,
 		'pmpro_bp_groups_page_viewing'		=> $can_view_groups_page,
-		'pmpro_bp_groups_join'				=> $can_join_groups,
+		'pmpro_bp_groups_join'				=> $can_join_groups,		
 		'pmpro_bp_private_messaging'		=> $pmpro_bp_private_messaging,
 		'pmpro_bp_public_messaging'			=> $pmpro_bp_public_messaging,
 		'pmpro_bp_send_friend_request'		=> $pmpro_bp_send_friend_request,
@@ -456,42 +456,36 @@ function pmpro_bp_restriction_settings_form( $level_id = NULL) {
 
 			<?php if ( $pmpro_bp_has_docs ) { ?>
 
-			<?php //viewing docs ?>
 			<tr>
-			<th scope="row" valign="top"><label for="pmpro_bp_docs_view"><?php _e('View Documents', 'pmpro-buddypress');?>:</label></th>
+			<th scope="row" valign="top"><label for="pmpro_bp_docs_view"><?php esc_html_e('View Documents', 'pmpro-buddypress');?>:</label></th>
 			<td>
 				<select name="pmpro_bp_docs_view" id="pmpro_bp_docs_view">
-						<option value='0' <?php if ( $pmpro_bp_docs_view == 0 ) echo 'selected'; ?>><?php _e('No', 'pmpro-buddypress');?></option>
-						<option value='1' <?php if ( $pmpro_bp_docs_view == 1 ) echo 'selected'; ?>><?php _e('Yes', 'pmpro-buddypress');?></option>
+					<option value="0" <?php selected( $pmpro_bp_docs_view, 0 ); ?>><?php _e('No', 'pmpro-buddypress');?></option>
+					<option value="1" <?php selected( $pmpro_bp_docs_view, 1 ); ?>><?php _e('Yes', 'pmpro-buddypress');?></option>
 				</select>
 				<p class="description">
-				<?php
-					if ( $level_id <> 0 ) {
-						_e( 'Can members of this level view documents and folders?', 'pmpro-buddypress' );
-					} else {
-						_e( 'Can non-member users view documents and folders?', 'pmpro-buddypress' );
-					}
-				?>
+				<?php if ( $level_id <> 0 ) {
+					esc_html_e( 'Can members of this level view documents and folders?', 'pmpro-buddypress' );
+				} else {
+					esc_html_e( 'Can non-member users view documents and folders?', 'pmpro-buddypress' );
+				} ?>
 				</p>
 			</td>
 			</tr>
 
-			<?php //uploading docs ?>
 			<tr>
-			<th scope="row" valign="top"><label for="pmpro_bp_docs_upload"><?php _e('Upload Documents', 'pmpro-buddypress');?>:</label></th>
+			<th scope="row" valign="top"><label for="pmpro_bp_docs_upload"><?php esc_html_e('Upload Documents', 'pmpro-buddypress');?>:</label></th>
 			<td>
 				<select name="pmpro_bp_docs_upload" id="pmpro_bp_docs_upload">
-						<option value='0' <?php if ( $pmpro_bp_docs_upload == 0 ) echo 'selected'; ?>><?php _e('No', 'pmpro-buddypress');?></option>
-						<option value='1' <?php if ( $pmpro_bp_docs_upload == 1 ) echo 'selected'; ?>><?php _e('Yes', 'pmpro-buddypress');?></option>
+					<option value="0" <?php selected( $pmpro_bp_docs_upload, 0 ); ?>><?php _e('No', 'pmpro-buddypress');?></option>
+					<option value="1" <?php selected( $pmpro_bp_docs_upload, 1 ); ?>><?php _e('Yes', 'pmpro-buddypress');?></option>
 				</select>
 				<p class="description">
-				<?php
-					if ( $level_id <> 0 ) {
-						_e( 'Can members of this level upload or create documents?', 'pmpro-buddypress' );
-					} else {
-						_e( 'Can non-member users upload or create documents?', 'pmpro-buddypress' );
-					}
-				?>
+				<?php if ( $level_id <> 0 ) {
+					esc_html_e( 'Can members of this level upload or create documents?', 'pmpro-buddypress' );
+				} else {
+					esc_html_e( 'Can non-member users upload or create documents?', 'pmpro-buddypress' );
+				} ?>
 				</p>
 			</td>
 			</tr>

--- a/includes/pmpro-buddypress-settings.php
+++ b/includes/pmpro-buddypress-settings.php
@@ -98,76 +98,35 @@ function pmpro_bp_buddpress_admin_page() {
 
 	require_once( PMPRO_DIR . '/adminpages/admin_header.php' ); ?>
 
-	<div id="poststuff">
-		<form action="" method="post" enctype="multipart/form-data">
+	<form action="" method="post">
+		<?php wp_nonce_field( 'pmpro_bp_save_settings', 'pmpro_bp_settings_nonce' ); ?>
+		<hr class="wp-header-end">
+		<h1><?php esc_html_e( 'Paid Memberships Pro - BuddyPress & BuddyBoss Add On Settings', 'pmpro-buddypress' ); ?></h1>
+		<p><?php printf( __( 'Restrict access to communities in BuddyPress and BuddyBoss for free or premium members with Paid Memberships Pro. <strong>This plugin is compatible with both BuddyPress and BuddyBoss.</strong> <a href="%s" target="_blank">Read the documentation</a> for more information about this Add On.', 'pmpro-buddypress' ), 'https://www.paidmembershipspro.com/add-ons/buddypress-integration/?utm_source=plugin&utm_medium=pmpro-buddpress-settings&utm_campaign=pmpro-buddypress' ); ?></p>
 
-		<h1><?php esc_attr_e( 'Paid Memberships Pro - BuddyPress & BuddyBoss Add On Settings', 'pmpro-buddypress' ); ?></h1>
-		<p><?php printf( __( 'Restrict access to communities in BuddyPress and BuddyBoss for free or premium members with the Paid Memberships Pro. <strong>This plugin is compatible with both BuddyPress and BuddyBoss.</strong> <a href="%s" target="_blank">Read the documentation</a> for more information about this Add On.', 'pmpro-buddypress' ), 'https://www.paidmembershipspro.com/add-ons/buddypress-integration/?utm_source=plugin&utm_medium=pmpro-buddpress-settings&utm_campaign=pmpro-buddypress' ); ?></p>
-		<hr />
-		<h3><?php esc_attr_e( 'Page Settings', 'pmpro-buddypress' ); ?></h3>
-		<p><?php esc_attr_e( 'This plugin redirects users to a specific page if they try to access restricted features. The user is redirected to the page assigned as the "Access Restricted" page under Memberships > Settings > Page Settings.', 'pmpro-buddypress' ); ?></p>
-		<?php
-			$pmprobp_restricted_page = $pmpro_pages['pmprobp_restricted'];
-			if ( ! empty( $pmprobp_restricted_page ) ) {
-				$msgt = '<span class="dashicons dashicons-yes"></span>' . esc_attr__( '"Access Restricted" page is configured.', 'pmpro-buddypress' );
-				$msgc = '#46b450';
-			} else {
-				$msgt = '<span class="dashicons dashicons-no"></span>' . esc_attr__( '"Access Restricted" page is not configured.', 'pmpro-buddypress' );
-				$msgc = '#a00';
-			}
-		?>
-		<p><strong style="color: <?php echo $msgc; ?>"><?php echo $msgt; ?></strong></p>
-		<p><a href="<?php echo admin_url('admin.php?page=pmpro-pagesettings');?>" class="button button-primary"><?php _e('Manage Page Settings', 'paid-memberships-pro' );?></a></p>
-		<hr />
-		<h3><?php esc_attr_e( 'Non-member User Settings', 'pmpro-buddypress' ); ?></h3>
-		<p><?php esc_attr_e( 'Set how BuddyPress should be locked down for users without a membership level.', 'pmpro-buddypress' ); ?></p>
-		<?php 
-			// Settings for Level 0 are for non-member users.
-			pmpro_bp_restriction_settings_form(0);
-		?>
-		<p class="submit">
-			<input name="savesettings" type="submit" class="button button-primary" value="<?php _e('Save All Settings', 'pmpro-buddypress' );?>" />
-		</p>
-		<hr />
-		<h3><?php esc_attr_e( 'Membership Level Settings', 'pmpro-buddypress' ); ?></h3>
-		<p><?php esc_attr_e( 'Edit your membership levels to set level-specific restrictions on community features.', 'pmpro-buddypress' ); ?></p>
-		<p><a href="<?php echo admin_url('admin.php?page=pmpro-membershiplevels');?>" class="button button-primary"><?php _e('Edit Membership Levels', 'paid-memberships-pro' );?></a></p>
-		<hr />		
-		<h3><?php esc_attr_e( 'General Settings', 'pmpro-buddypress' ); ?></h3>
-		<?php if ( defined( 'BP_PLATFORM_VERSION' ) ) { ?>
-			<p class="description"><?php esc_html_e( 'Note: These settings apply to sites running BuddyPress or BuddyBoss.', 'pmpro-buddypress' ); ?></p>
-		<?php } ?>
-		<table class="form-table">
-		<tbody>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="pmpro_bp_register"><?php _e("Registration Page", 'pmpro-buddypress');?></label>
-				</th>
-				<td>
-					<select id="pmpro_bp_register" name="pmpro_bp_register">
-						<option value="pmpro" <?php if($pmpro_bp_register == 'pmpro') { ?>selected="selected"<?php } ?>><?php _e('Use PMPro Levels Page', 'pmpro-buddypress');?></option>
-						<option value="buddypress" <?php if($pmpro_bp_register == 'buddypress') { ?>selected="selected"<?php } ?>><?php _e('Use BuddyPress Registration Page', 'pmpro-buddypress');?></option>
-					</select>
-				</td>
-			</tr>
-			
-			<tr>
-				<th scope="row" valign="top">
-					<label for="pmpro_bp_level_profile"><?php _e("Show Membership Level on Profiles?", 'pmpro-buddypress');?></label>
-				</th>
-				<td>
-					<select id="pmpro_bp_level_profile" name="pmpro_bp_level_profile">
-						<option value="yes" <?php if($pmpro_bp_level_profile == 'yes') { ?>selected="selected"<?php } ?>><?php _e('Yes', 'pmpro-buddypress');?></option>
-						<option value="no" <?php if($pmpro_bp_level_profile == 'no') { ?>selected="selected"<?php } ?>><?php _e('No', 'pmpro-buddypress');?></option>
-					</select>
-				</td>
-			</tr>
-		</tbody>
-		</table>		
-		<p class="submit">
-			<input name="savesettings" type="submit" class="button button-primary" value="<?php _e('Save All Settings', 'pmpro-buddypress');?>" />
-		</p>
-
+		<div id="pmpro-bp-page-settings" class="pmpro_section" data-visibility="shown" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
+					<span class="dashicons dashicons-arrow-up-alt2"></span>
+					<?php esc_html_e( 'Page Settings', 'pmpro-buddypress' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside">
+				<p><?php esc_html_e( 'This plugin redirects users to a specific page if they try to access restricted features. The user is redirected to the page assigned as the "Access Restricted" page under Memberships > Settings > Page Settings.', 'pmpro-buddypress' ); ?></p>
+				<?php
+					$pmprobp_restricted_page = $pmpro_pages['pmprobp_restricted'];
+					if ( ! empty( $pmprobp_restricted_page ) ) {
+						$page_msgt = '<span class="dashicons dashicons-yes"></span>' . esc_html__( '"Access Restricted" page is configured.', 'pmpro-buddypress' );
+						$page_msgc = '#46b450';
+					} else {
+						$page_msgt = '<span class="dashicons dashicons-no"></span>' . esc_html__( '"Access Restricted" page is not configured.', 'pmpro-buddypress' );
+						$page_msgc = '#a00';
+					}
+				?>
+				<p><strong style="color: <?php echo esc_attr( $page_msgc ); ?>"><?php echo $page_msgt; ?></strong></p>
+				<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-pagesettings' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Manage Page Settings', 'pmpro-buddypress' ); ?></a></p>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
 
 		<div id="pmpro-bp-non-member-settings" class="pmpro_section" data-visibility="hidden" data-activated="true">
 			<div class="pmpro_section_toggle">
@@ -236,10 +195,10 @@ function pmpro_bp_buddpress_admin_page() {
 											break;
 										case PMPROBP_SPECIFIC_FEATURES:
 											$feature_keys = array( 'pmpro_bp_group_creation', 'pmpro_bp_group_single_viewing', 'pmpro_bp_groups_page_viewing', 'pmpro_bp_groups_join', 'pmpro_bp_private_messaging', 'pmpro_bp_public_messaging', 'pmpro_bp_send_friend_request', 'pmpro_bp_member_directory' );
-											if ( function_exists( 'bb_user_can_create_document' ) || function_exists( 'bp_docs_user_can' ) ) {
-												$feature_keys[] = 'pmpro_bp_docs_view';
-												$feature_keys[] = 'pmpro_bp_docs_upload';
-											}
+										if ( function_exists( 'bb_user_can_create_document' ) || function_exists( 'bp_docs_user_can' ) ) {
+											$feature_keys[] = 'pmpro_bp_docs_view';
+											$feature_keys[] = 'pmpro_bp_docs_upload';
+										}
 											$enabled      = 0;
 											foreach ( $feature_keys as $feature_key ) {
 												if ( ! empty( $level_options[ $feature_key ] ) ) {

--- a/includes/pmpro-buddypress-settings.php
+++ b/includes/pmpro-buddypress-settings.php
@@ -29,16 +29,18 @@ function pmpro_bp_buddpress_admin_page() {
 	//get/set settings
 	if(!empty($_REQUEST['savesettings'])) {
 		// Non-member user Restrictions
-		$can_create_groups = intval( $_REQUEST['pmpro_bp_group_creation'] );
-		$can_view_single_group = intval( $_REQUEST['pmpro_bp_group_single_viewing'] );
-		$can_view_groups_page = intval( $_REQUEST['pmpro_bp_groups_page_viewing'] );
-		$can_join_groups = intval( $_REQUEST['pmpro_bp_groups_join'] );
-		$pmpro_bp_restrictions = intval( $_REQUEST['pmpro_bp_restrictions'] );
-		$pmpro_bp_public_messaging = intval( $_REQUEST['pmpro_bp_public_messaging'] );
-		$pmpro_bp_private_messaging = intval( $_REQUEST['pmpro_bp_private_messaging'] );
-		$pmpro_bp_send_friend_request = intval( $_REQUEST['pmpro_bp_send_friend_request'] );
-		$pmpro_bp_member_directory = intval( $_REQUEST['pmpro_bp_member_directory'] );		
-			
+		$can_create_groups = isset( $_POST['pmpro_bp_group_creation'] ) ? intval( $_POST['pmpro_bp_group_creation'] ) : 0;
+		$can_view_single_group = isset( $_POST['pmpro_bp_group_single_viewing'] ) ? intval( $_POST['pmpro_bp_group_single_viewing'] ) : 0;
+		$can_view_groups_page = isset( $_POST['pmpro_bp_groups_page_viewing'] ) ? intval( $_POST['pmpro_bp_groups_page_viewing'] ) : 0;
+		$can_join_groups = isset( $_POST['pmpro_bp_groups_join'] ) ? intval( $_POST['pmpro_bp_groups_join'] ) : 0;
+		$pmpro_bp_restrictions = isset( $_POST['pmpro_bp_restrictions'] ) ? intval( $_POST['pmpro_bp_restrictions'] ) : 0;
+		$pmpro_bp_public_messaging = isset( $_POST['pmpro_bp_public_messaging'] ) ? intval( $_POST['pmpro_bp_public_messaging'] ) : 0;
+		$pmpro_bp_private_messaging = isset( $_POST['pmpro_bp_private_messaging'] ) ? intval( $_POST['pmpro_bp_private_messaging'] ) : 0;
+		$pmpro_bp_send_friend_request = isset( $_POST['pmpro_bp_send_friend_request'] ) ? intval( $_POST['pmpro_bp_send_friend_request'] ) : 0;
+		$pmpro_bp_member_directory = isset( $_POST['pmpro_bp_member_directory'] ) ? intval( $_POST['pmpro_bp_member_directory'] ) : 0;
+		$pmpro_bp_docs_view = isset( $_POST['pmpro_bp_docs_view'] ) ? intval( $_POST['pmpro_bp_docs_view'] ) : 0;
+		$pmpro_bp_docs_upload = isset( $_POST['pmpro_bp_docs_upload'] ) ? intval( $_POST['pmpro_bp_docs_upload'] ) : 0;
+
 		$pmpro_bp_options = array(
 			'pmpro_bp_restrictions'				=> $pmpro_bp_restrictions,
 			'pmpro_bp_group_creation'			=> $can_create_groups,
@@ -49,14 +51,28 @@ function pmpro_bp_buddpress_admin_page() {
 			'pmpro_bp_public_messaging'			=> $pmpro_bp_public_messaging,
 			'pmpro_bp_send_friend_request'		=> $pmpro_bp_send_friend_request,
 			'pmpro_bp_member_directory'			=> $pmpro_bp_member_directory,
+			'pmpro_bp_docs_view'				=> $pmpro_bp_docs_view,
+			'pmpro_bp_docs_upload'				=> $pmpro_bp_docs_upload,
 			'pmpro_bp_group_automatic_add'		=> array(),
 			'pmpro_bp_group_can_request_invite'	=> array(),
 			'pmpro_bp_member_types'				=> array());
 		update_option('pmpro_bp_options_users', $pmpro_bp_options, 'no');
 
 		// General Settings
-		update_option( 'pmpro_bp_registration_page', $_POST['pmpro_bp_register'] );
-		update_option( 'pmpro_bp_show_level_on_bp_profile', $_POST['pmpro_bp_level_profile'], 'no' ) ;
+		$register_value = isset( $_POST['pmpro_bp_register'] ) ? sanitize_text_field( wp_unslash( $_POST['pmpro_bp_register'] ) ) : 'buddypress';
+		if ( ! in_array( $register_value, array( 'pmpro', 'buddypress' ), true ) ) {
+			$register_value = 'buddypress';
+		}
+		update_option( 'pmpro_bp_registration_page', $register_value );
+
+		$level_profile_value = isset( $_POST['pmpro_bp_level_profile'] ) ? sanitize_text_field( wp_unslash( $_POST['pmpro_bp_level_profile'] ) ) : 'no';
+		if ( ! in_array( $level_profile_value, array( 'yes', 'no' ), true ) ) {
+			$level_profile_value = 'no';
+		}
+		update_option( 'pmpro_bp_show_level_on_bp_profile', $level_profile_value, 'no' );
+
+		// Xprofile Field Mapping
+		pmpro_bp_save_xprofile_field_map();
 
 		// Assume Success
 		$msg = 1;
@@ -146,6 +162,191 @@ function pmpro_bp_buddpress_admin_page() {
 			<input name="savesettings" type="submit" class="button button-primary" value="<?php _e('Save All Settings', 'pmpro-buddypress');?>" />
 		</p>
 
-		</form>
-<?php
+
+		<div id="pmpro-bp-non-member-settings" class="pmpro_section" data-visibility="hidden" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
+					<span class="dashicons dashicons-arrow-down-alt2"></span>
+					<?php esc_html_e( 'Non-member User Settings', 'pmpro-buddypress' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside" style="display: none;">
+				<p><?php esc_html_e( 'Set how BuddyPress should be locked down for users without a membership level.', 'pmpro-buddypress' ); ?></p>
+				<?php
+					// Settings for Level 0 are for non-member users.
+					pmpro_bp_restriction_settings_form(0);
+				?>
+				<p class="submit">
+					<input name="savesettings" type="submit" class="button button-primary" value="<?php esc_attr_e( 'Save All Settings', 'pmpro-buddypress' ); ?>" />
+				</p>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
+
+		<div id="pmpro-bp-level-settings" class="pmpro_section" data-visibility="hidden" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
+					<span class="dashicons dashicons-arrow-down-alt2"></span>
+					<?php esc_html_e( 'Membership Level Settings', 'pmpro-buddypress' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside" style="display: none;">
+				<p><?php esc_html_e( 'Edit your membership levels to set level-specific restrictions on community features. These settings are managed in the "BuddyPress Restrictions" section when editing a membership level.', 'pmpro-buddypress' ); ?></p>
+				<?php
+					$pmpro_bp_levels = pmpro_getAllLevels( true, true );
+					if ( function_exists( 'pmpro_sort_levels_by_order' ) ) {
+						$pmpro_bp_levels = pmpro_sort_levels_by_order( $pmpro_bp_levels );
+					}
+				?>
+				<?php if ( empty( $pmpro_bp_levels ) ) { ?>
+					<p><strong><?php esc_html_e( 'No membership levels found.', 'pmpro-buddypress' ); ?></strong> <a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-membershiplevels' ) ); ?>"><?php esc_html_e( 'Create a membership level to get started.', 'pmpro-buddypress' ); ?></a></p>
+				<?php } else { ?>
+					<table class="widefat striped">
+						<thead>
+							<tr>
+								<th scope="col"><?php esc_html_e( 'Level', 'pmpro-buddypress' ); ?></th>
+								<th scope="col"><?php esc_html_e( 'BuddyPress Access', 'pmpro-buddypress' ); ?></th>
+								<th scope="col"><?php esc_html_e( 'Member Types', 'pmpro-buddypress' ); ?></th>
+								<th scope="col"><?php esc_html_e( 'Auto-Join Groups', 'pmpro-buddypress' ); ?></th>
+								<th scope="col"><?php esc_html_e( 'Actions', 'pmpro-buddypress' ); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ( $pmpro_bp_levels as $pmpro_bp_level ) { ?>
+								<?php
+									// Read the raw per-level option so "use non-member settings" is
+									// reported as such instead of being resolved to its effective values.
+									$level_options = get_option( 'pmpro_bp_options_' . $pmpro_bp_level->id, array() );
+									$level_options = array_merge( pmpro_bp_get_level_options( -1 ), (array) $level_options );
+
+									$access_note = '';
+									switch ( (int) $level_options['pmpro_bp_restrictions'] ) {
+										case PMPROBP_USE_NON_MEMBER_SETTINGS:
+											$access_label     = __( 'Non-member Settings', 'pmpro-buddypress' );
+											$access_tag_class = 'info';
+											break;
+										case PMPROBP_GIVE_ALL_ACCESS:
+											$access_label     = __( 'Unlocked', 'pmpro-buddypress' );
+											$access_tag_class = 'success';
+											break;
+										case PMPROBP_SPECIFIC_FEATURES:
+											$feature_keys = array( 'pmpro_bp_group_creation', 'pmpro_bp_group_single_viewing', 'pmpro_bp_groups_page_viewing', 'pmpro_bp_groups_join', 'pmpro_bp_private_messaging', 'pmpro_bp_public_messaging', 'pmpro_bp_send_friend_request', 'pmpro_bp_member_directory' );
+											if ( function_exists( 'bb_user_can_create_document' ) || function_exists( 'bp_docs_user_can' ) ) {
+												$feature_keys[] = 'pmpro_bp_docs_view';
+												$feature_keys[] = 'pmpro_bp_docs_upload';
+											}
+											$enabled      = 0;
+											foreach ( $feature_keys as $feature_key ) {
+												if ( ! empty( $level_options[ $feature_key ] ) ) {
+													$enabled++;
+												}
+											}
+											$access_label     = __( 'Partial Access', 'pmpro-buddypress' );
+											$access_tag_class = 'alert';
+											// translators: %1$d is the number of unlocked features, %2$d is the total number of features.
+											$access_note      = sprintf( __( '%1$d of %2$d features unlocked', 'pmpro-buddypress' ), $enabled, count( $feature_keys ) );
+											break;
+										case PMPROBP_LOCK_ALL_ACCESS:
+										default:
+											$access_label     = __( 'Locked', 'pmpro-buddypress' );
+											$access_tag_class = 'error';
+											break;
+									}
+
+									// Member type names for this level. The saved option may be false or
+									// contain empty entries when nothing is selected, so filter those out.
+									$member_type_names = array();
+									foreach ( array_filter( (array) $level_options['pmpro_bp_member_types'] ) as $member_type ) {
+										$member_type_object  = function_exists( 'bp_get_member_type_object' ) ? bp_get_member_type_object( $member_type ) : null;
+										$member_type_names[] = ! empty( $member_type_object->labels['singular_name'] ) ? $member_type_object->labels['singular_name'] : $member_type;
+									}
+
+									// Group names this level is automatically added to (same false/empty handling).
+									$group_names = array();
+									foreach ( array_filter( (array) $level_options['pmpro_bp_group_automatic_add'] ) as $group_id ) {
+										$group         = function_exists( 'groups_get_group' ) ? groups_get_group( $group_id ) : null;
+										$group_names[] = ! empty( $group->name ) ? $group->name : '#' . (int) $group_id;
+									}
+
+									$level_edit_url = admin_url( 'admin.php?page=pmpro-membershiplevels&edit=' . (int) $pmpro_bp_level->id );
+								?>
+								<tr>
+									<td><a href="<?php echo esc_url( $level_edit_url ); ?>" target="_blank"><?php echo esc_html( $pmpro_bp_level->name ); ?></a></td>
+									<td>
+										<span class="pmpro_tag pmpro_tag-<?php echo esc_attr( $access_tag_class ); ?>"><?php echo esc_html( $access_label ); ?></span>
+										<?php if ( ! empty( $access_note ) ) { ?>
+											<p class="description"><?php echo esc_html( $access_note ); ?></p>
+										<?php } ?>
+									</td>
+									<td><?php echo ! empty( $member_type_names ) ? esc_html( implode( ', ', $member_type_names ) ) : '&#8212;'; ?></td>
+									<td><?php echo ! empty( $group_names ) ? esc_html( implode( ', ', $group_names ) ) : '&#8212;'; ?></td>
+									<td><a href="<?php echo esc_url( $level_edit_url ); ?>" target="_blank"><?php esc_html_e( 'Edit Level', 'pmpro-buddypress' ); ?></a></td>
+								</tr>
+							<?php } ?>
+						</tbody>
+					</table>
+				<?php } ?>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
+
+		<div id="pmpro-bp-general-settings" class="pmpro_section" data-visibility="hidden" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
+					<span class="dashicons dashicons-arrow-down-alt2"></span>
+					<?php esc_html_e( 'General Settings', 'pmpro-buddypress' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside" style="display: none;">
+				<?php if ( defined( 'BP_PLATFORM_VERSION' ) ) { ?>
+					<p class="description"><?php esc_html_e( 'Note: These settings apply to sites running BuddyPress or BuddyBoss.', 'pmpro-buddypress' ); ?></p>
+				<?php } ?>
+				<table class="form-table">
+				<tbody>
+					<tr>
+						<th scope="row" valign="top">
+							<label for="pmpro_bp_register"><?php esc_html_e( 'Registration Page', 'pmpro-buddypress' ); ?></label>
+						</th>
+						<td>
+							<select id="pmpro_bp_register" name="pmpro_bp_register">
+								<option value="pmpro" <?php selected( $pmpro_bp_register, 'pmpro' ); ?>><?php esc_html_e( 'Use PMPro Levels Page', 'pmpro-buddypress' ); ?></option>
+								<option value="buddypress" <?php selected( $pmpro_bp_register, 'buddypress' ); ?>><?php esc_html_e( 'Use BuddyPress Registration Page', 'pmpro-buddypress' ); ?></option>
+							</select>
+						</td>
+					</tr>
+
+					<tr>
+						<th scope="row" valign="top">
+							<label for="pmpro_bp_level_profile"><?php esc_html_e( 'Show Membership Level on Profiles?', 'pmpro-buddypress' ); ?></label>
+						</th>
+						<td>
+							<select id="pmpro_bp_level_profile" name="pmpro_bp_level_profile">
+								<option value="yes" <?php selected( $pmpro_bp_level_profile, 'yes' ); ?>><?php esc_html_e( 'Yes', 'pmpro-buddypress' ); ?></option>
+								<option value="no" <?php selected( $pmpro_bp_level_profile, 'no' ); ?>><?php esc_html_e( 'No', 'pmpro-buddypress' ); ?></option>
+							</select>
+						</td>
+					</tr>
+				</tbody>
+				</table>
+				<p class="submit">
+					<input name="savesettings" type="submit" class="button button-primary" value="<?php esc_attr_e( 'Save All Settings', 'pmpro-buddypress' ); ?>" />
+				</p>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
+
+		<div id="pmpro-bp-xprofile-mapping" class="pmpro_section" data-visibility="hidden" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
+					<span class="dashicons dashicons-arrow-down-alt2"></span>
+					<?php esc_html_e( 'Extended Profile Field Mapping', 'pmpro-buddypress' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside" style="display: none;">
+				<?php pmpro_bp_render_xprofile_mapping_section(); ?>
+				<p class="submit">
+					<input name="savesettings" type="submit" class="button button-primary" value="<?php esc_attr_e( 'Save All Settings', 'pmpro-buddypress' ); ?>" />
+				</p>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
+	</form>
+	<?php
+	require_once( PMPRO_DIR . '/adminpages/admin_footer.php' );
 }

--- a/pmpro-buddypress.php
+++ b/pmpro-buddypress.php
@@ -40,9 +40,9 @@ require_once( PMPROBP_DIR . '/includes/groups.php' );
 require_once( PMPROBP_DIR . '/includes/member-types.php' );
 require_once( PMPROBP_DIR . '/includes/profiles.php' );
 require_once( PMPROBP_DIR . '/includes/xprofile-mapping.php' );
+require_once( PMPROBP_DIR . '/includes/documents.php' );
 require_once( PMPROBP_DIR . '/includes/registration.php' );
 require_once( PMPROBP_DIR . '/includes/restrictions.php' );
-require_once( PMPROBP_DIR . '/includes/documents.php' );
 
 if ( class_exists( 'PMPro_Approvals' ) ) {
     require_once( PMPROBP_DIR . '/includes/approvals.php' );

--- a/pmpro-buddypress.php
+++ b/pmpro-buddypress.php
@@ -41,6 +41,7 @@ require_once( PMPROBP_DIR . '/includes/member-types.php' );
 require_once( PMPROBP_DIR . '/includes/profiles.php' );
 require_once( PMPROBP_DIR . '/includes/registration.php' );
 require_once( PMPROBP_DIR . '/includes/restrictions.php' );
+require_once( PMPROBP_DIR . '/includes/documents.php' );
 
 if ( class_exists( 'PMPro_Approvals' ) ) {
     require_once( PMPROBP_DIR . '/includes/approvals.php' );


### PR DESCRIPTION
## Summary

- Adds two new per-level settings: View Documents and Upload Documents
- Controls access to BP Docs and BuddyBoss Platform Documents based on membership level
- Settings appear only when a docs plugin is active; Give All Access unlocks docs automatically

Resolves: https://github.com/strangerstudios/pmpro-buddypress/issues/76

## Changes

- **includes/documents.php** (new): Hooks into BP Docs filters (bp_docs_user_can, bp_docs_current_user_can_create_in_context, template_redirect) and BuddyBoss AJAX actions (wp_ajax_document_document_upload, wp_ajax_document_document_save) at priority 1 to enforce restrictions before the platform handlers run
- **includes/common.php**: Adds pmpro_bp_docs_view and pmpro_bp_docs_upload to defaults, non-member mirror block, and multi-level merge
- **includes/membership-level-settings.php**: Form fields and save logic for the two new settings
- **includes/pmpro-buddypress-settings.php**: Saves new fields for non-member user settings; includes them in the feature count in the levels overview table
- **pmpro-buddypress.php**: Loads includes/documents.php

## Test plan

- [ ] Activate BP Docs - confirm View Documents and Upload Documents fields appear under BuddyPress Restrictions > Specific Features
- [ ] Set Upload Documents to No for a level, log in as that member, confirm creating a doc is blocked
- [ ] Set View Documents to No, confirm navigating to the docs component redirects to the Access Restricted page
- [ ] Activate BuddyBoss Platform - confirm fields appear and upload is blocked for both profile and group document uploads
- [ ] With neither plugin active, confirm the fields do not appear
- [ ] Confirm Give All Access unlocks docs without needing to set the individual toggles

Generated with [Claude Code](https://claude.com/claude-code)